### PR TITLE
feat: migrate List lemmas from mathlib

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -531,7 +531,7 @@ modifyNthTail f 2 [a, b, c] = [a, b] ++ f [c]
   | n+1, a :: l => a :: modifyNthTail f n l
 
 /-- Apply `f` to the head of the list, if it exists. -/
-@[simp, inline] def modifyHead (f : α → α) : List α → List α
+@[inline] def modifyHead (f : α → α) : List α → List α
   | [] => []
   | a :: l => f a :: l
 
@@ -548,8 +548,8 @@ def modifyNthTR (f : α → α) (n : Nat) (l : List α) : List α := go l n #[] 
   | a :: l, n+1, acc => go l n (acc.push a)
 
 theorem modifyNthTR_go_eq : ∀ l n, modifyNthTR.go f l n acc = acc.data ++ modifyNth f n l
-  | [], n => by cases n <;> simp [modifyNthTR.go, modifyNth]
-  | a :: l, 0 => by simp [modifyNthTR.go, modifyNth]
+  | [], n => by cases n <;> simp [modifyHead, modifyNthTR.go, modifyNth]
+  | a :: l, 0 => by simp [modifyHead, modifyNthTR.go, modifyNth]
   | a :: l, n+1 => by simp [modifyNthTR.go, modifyNth, modifyNthTR_go_eq l]
 
 @[csimp] theorem modifyNth_eq_modifyNthTR : @modifyNth = @modifyNthTR := by

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -381,23 +381,6 @@ theorem subset_singleton_iff {a : α} {L : List α} : L ⊆ [a] ↔ ∃ n, L = r
 @[simp] theorem join_replicate_nil (n : Nat) : join (replicate n []) = @nil α := by
   induction n <;> [rfl; simp only [*, replicate, join, append_nil]]
 
-/-! ### pure -/
-
--- Porting note: simp can prove this
--- @[simp]
-theorem bind_singleton (f : α → List β) (x : α) : [x].bind f = f x :=
-  append_nil $ f x
-
-@[simp] theorem bind_singleton' (l : List α) : (l.bind fun x => [x]) = l := by
-  induction l <;> simp [*]
-
-theorem map_eq_bind {α β} (f : α → β) (l : List α) : map f l = l.bind fun x => [f x] := by
-  simp only [←map_singleton]
-  rw [← bind_singleton' l, bind_map, bind_singleton']
-
-theorem bind_assoc {α β} (l : List α) (f : α → List β) (g : β → List γ) :
-    (l.bind f).bind g = l.bind fun x => (f x).bind g := by induction l <;> simp [*]
-
 /-! ### getLast -/
 
 @[simp]

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -388,10 +388,14 @@ theorem getLast_cons' {a : α} {l : List α} : ∀ (h₁ : a :: l ≠ nil) (h₂
   getLast (a :: l) h₁ = getLast l h₂ := by
   induction l <;> intros; {contradiction}; rfl
 
-@[simp] theorem getLast_append {a : α} : ∀ (l : List α) h, getLast (l ++ [a]) h = a
-  | [], _ => rfl
-  | a::t, _ => by
-    simp [getLast_cons' _ fun H => cons_ne_nil _ _ (append_eq_nil.1 H).2, getLast_append t]
+@[simp] theorem getLast_append_singleton {a : α} :
+  ∀ (l : List α),
+    getLast (l ++ [a]) (append_ne_nil_of_ne_nil_right l _ (cons_ne_nil a _)) = a
+  | [] => rfl
+  | a::t => by
+    simp [
+      getLast_cons' _ fun H => cons_ne_nil _ _ (append_eq_nil.1 H).2,
+      getLast_append_singleton t]
 
 theorem getLast_concat {h : concat l a ≠ []} : getLast (concat l a) h = a :=
   by simp
@@ -402,12 +406,7 @@ theorem eq_nil_or_concat : ∀ l : List α, l = [] ∨ ∃ L b, l = L ++ [b]
     | _, .inl rfl => .inr ⟨[], a, rfl⟩
     | _, .inr ⟨L, b, rfl⟩ => .inr ⟨a::L, b, rfl⟩
 
-theorem getLast_append_singleton {a : α} (l : List α) :
-    getLast (l ++ [a]) (append_ne_nil_of_ne_nil_right l _ (cons_ne_nil a _)) = a := by
-  simp
-
--- Porting note: name should be fixed upstream
-theorem getLast_append' (l₁ l₂ : List α) (h : l₂ ≠ []) :
+theorem getLast_append (l₁ l₂ : List α) (h : l₂ ≠ []) :
     getLast (l₁ ++ l₂) (append_ne_nil_of_ne_nil_right l₁ l₂ h) = getLast l₂ h := by
   induction l₁
   · simp

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -687,9 +687,26 @@ theorem head!_mem_self [Inhabited α] {l : List α} (h : l ≠ nil) : l.head! �
 @[simp] theorem head?_map (f : α → β) (l) : head? (map f l) = (head? l).map f := by
   cases l <;> rfl
 
-@[simp 1100]
+-- List.modifyHead_modifyHead.{u_1} Left-hand side simplifies from
+--   List.modifyHead g (List.modifyHead f l)
+-- to
+--   match
+--   match l with
+--   | [] => []
+--   | a :: l => f a :: l with
+-- | [] => []
+-- | a :: l => g a :: l
+-- using
+--   simp only [@List.modifyHead]
+-- Try to change the left-hand side to the simplified term!
+--
+-- @[simp 1100]
 theorem modifyHead_modifyHead (l : List α) (f g : α → α) :
-    (l.modifyHead f).modifyHead g = l.modifyHead (g ∘ f) := by cases l <;> simp
+    (l.modifyHead f).modifyHead g = l.modifyHead (g ∘ f) := by
+  cases l
+  · simp only [modifyHead]
+  · simp only [modifyHead]
+    rfl
 
 /-! ### tail -/
 
@@ -970,7 +987,9 @@ theorem getLast?_eq_get? : ∀ (l : List α), getLast? l = l.get? (l.length - 1)
   | [], a => rfl
   | b :: l, a => by rw [cons_append, length_cons]; simp only [get?, get?_concat_length]
 
-@[simp] theorem getLast?_concat (l : List α) : getLast? (l ++ [a]) = some a := by
+-- simp can prove this
+-- @[simp]
+theorem getLast?_concat (l : List α) : getLast? (l ++ [a]) = some a := by
   simp [getLast?_eq_get?]
 
 @[simp] theorem getLastD_concat (a b l) : @getLastD α (l ++ [b]) a = b := by

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -630,7 +630,7 @@ theorem head!_mem_head? [Inhabited α] : ∀ {l : List α}, l ≠ [] → head! l
 theorem cons_head!_tail [Inhabited α] : ∀ {l : List α}, l ≠ [] → head! l :: tail l = l
   | _::_, _ => rfl
 
-theorem head!_mem_self [Inhabited α] : ∀ {l : List α}, l ≠ [] → l.head! ∈ l 
+theorem head!_mem_self [Inhabited α] : ∀ {l : List α}, l ≠ [] → l.head! ∈ l
   | _::_, _ => mem_cons_self ..
 
 @[simp] theorem head?_map (f : α → β) (l) : head? (map f l) = (head? l).map f := by
@@ -654,7 +654,7 @@ theorem tail_eq_tail? (l) : @tail α l = (tail? l).getD [] := by simp [tail_eq_t
 theorem tail_append_singleton_of_ne_nil {a : α} : ∀ {l}, l ≠ [] → tail (l ++ [a]) = tail l ++ [a]
   | _::_, _ => rfl
 
-theorem tail_append_of_ne_nil : ∀ (l l' : List α), l ≠ [] → (l ++ l').tail = l.tail ++ l' 
+theorem tail_append_of_ne_nil : ∀ (l l' : List α), l ≠ [] → (l ++ l').tail = l.tail ++ l'
   | _::_, _, _ => rfl
 
 /-! ### next? -/

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -29,7 +29,7 @@ theorem cons_inj (a : α) {l l' : List α} : a :: l = a :: l' ↔ l = l' :=
   ⟨tail_eq_of_cons_eq, congrArg _⟩
 
 theorem cons_eq_cons {a b : α} {l l' : List α} : a :: l = b :: l' ↔ a = b ∧ l = l' :=
-  ⟨List.cons.inj, fun h => h.1 ▸ h.2 ▸ rfl⟩
+  List.cons.injEq .. ▸ .rfl
 
 theorem exists_cons_of_ne_nil : ∀ {l : List α}, l ≠ [] → ∃ b L, l = b :: L
   | c :: l', _ => ⟨c, l', rfl⟩
@@ -48,7 +48,7 @@ theorem length_pos_iff_exists_mem {l : List α} : 0 < length l ↔ ∃ a, a ∈ 
   ⟨exists_mem_of_length_pos, fun ⟨_, h⟩ => length_pos_of_mem h⟩
 
 theorem exists_cons_of_length_pos : ∀ {l : List α}, 0 < l.length → ∃ h t, l = h :: t
-  | h::t, _ => ⟨h, t, rfl⟩
+  | _::_, _ => ⟨_, _, rfl⟩
 
 theorem length_pos_iff_exists_cons :
     ∀ {l : List α}, 0 < l.length ↔ ∃ h t, l = h :: t :=
@@ -56,7 +56,7 @@ theorem length_pos_iff_exists_cons :
 
 theorem exists_cons_of_length_succ :
     ∀ {l : List α}, l.length = n + 1 → ∃ h t, l = h :: t
-  | h::t, _ => ⟨h, t, rfl⟩
+  | _::_, _ => ⟨_, _, rfl⟩
 
 theorem length_pos {l : List α} : 0 < length l ↔ l ≠ [] :=
   Nat.pos_iff_ne_zero.trans (not_congr length_eq_zero)
@@ -175,14 +175,10 @@ theorem concat_cons (a b : α) (l : List α) : concat (a :: l) b = a :: concat l
   rfl
 
 theorem init_eq_of_concat_eq {a : α} {l₁ l₂ : List α} : concat l₁ a = concat l₂ a → l₁ = l₂ := by
-  intro h
-  simp at h
-  assumption
+  simp
 
 theorem last_eq_of_concat_eq {a b : α} {l : List α} : concat l a = concat l b → a = b := by
-  intro h
-  simp at h
-  assumption
+  simp
 
 theorem concat_ne_nil (a : α) (l : List α) : concat l a ≠ [] := by simp
 
@@ -378,11 +374,8 @@ theorem join_replicate_nil (n : Nat) : join (replicate n []) = @nil α := by
 /-! ### getLast -/
 
 @[simp]
-theorem getLast_cons {a : α} {l : List α} :
-    ∀ h : l ≠ nil, getLast (a :: l) (cons_ne_nil a l) = getLast l h := by
-  induction l <;> intros
-  · contradiction
-  · rfl
+theorem getLast_cons {a : α} : ∀ {l} (h : l ≠ nil), getLast (a :: l) (cons_ne_nil a l) = getLast l h
+  | _::_, _ => rfl
 
 theorem getLast_cons' {a : α} {l : List α} : ∀ (h₁ : a :: l ≠ nil) (h₂ : l ≠ nil),
   getLast (a :: l) h₁ = getLast l h₂ := by
@@ -611,43 +604,34 @@ theorem head?_eq_head : ∀ l h, @head? α l = some (head l h)
   | _::_, _ => rfl
 
 theorem eq_cons_of_mem_head? {x : α} : ∀ {l : List α}, x ∈ l.head? → l = x :: tail l
-  | [], h => (Option.not_mem_none _ h).elim
-  | a :: l, h => by
-    simp only [head?, Option.mem_def, Option.some_inj] at h
-    exact h ▸ rfl
+  | _ :: _, rfl => rfl
 
 theorem mem_of_mem_head? {x : α} {l : List α} (h : x ∈ l.head?) : x ∈ l :=
   (eq_cons_of_mem_head? h).symm ▸ mem_cons_self _ _
 
 @[simp] theorem head!_cons [Inhabited α] (a : α) (l : List α) : head! (a :: l) = a := rfl
 
-@[simp] theorem head!_append [Inhabited α] (t : List α) {s : List α} (h : s ≠ []) :
-    head! (s ++ t) = head! s := by
-  induction s; contradiction; rfl
+@[simp] theorem head!_append [Inhabited α] (t : List α) : ∀ {s}, s ≠ [] → head! (s ++ t) = head! s
+  | _::_, _ => rfl
 
-theorem head?_append {s t : List α} {x : α} (h : x ∈ s.head?) : x ∈ (s ++ t).head? := by
-  cases s; contradiction; exact h
+theorem head?_append : ∀ {s t : List α} {x}, x ∈ s.head? → x ∈ (s ++ t).head?
+  | _::_, _, _, rfl => rfl
 
 theorem head?_append_of_ne_nil :
     ∀ (l₁ : List α) {l₂ : List α} (_ : l₁ ≠ []), head? (l₁ ++ l₂) = head? l₁
   | _ :: _, _, _ => rfl
 
 theorem cons_head?_tail : ∀ {l : List α} {a : α}, a ∈ head? l → a :: tail l = l
-  | [], a, h => by contradiction
-  | b :: l, a, h => by
-    simp at h
-    simp [h]
+  | _ :: _, _, rfl => rfl
 
 theorem head!_mem_head? [Inhabited α] : ∀ {l : List α}, l ≠ [] → head! l ∈ head? l
-  | [], h => by contradiction
-  | a :: l, _ => rfl
+  | _ :: _, _ => rfl
 
-theorem cons_head!_tail [Inhabited α] {l : List α} (h : l ≠ []) : head! l :: tail l = l :=
-  cons_head?_tail (head!_mem_head? h)
+theorem cons_head!_tail [Inhabited α] : ∀ {l : List α}, l ≠ [] → head! l :: tail l = l
+  | _::_, _ => rfl
 
-theorem head!_mem_self [Inhabited α] {l : List α} (h : l ≠ nil) : l.head! ∈ l := by
-  have h' := mem_cons_self l.head! l.tail
-  rwa [cons_head!_tail h] at h'
+theorem head!_mem_self [Inhabited α] : ∀ {l : List α}, l ≠ [] → l.head! ∈ l 
+  | _::_, _ => mem_cons_self ..
 
 @[simp] theorem head?_map (f : α → β) (l) : head? (map f l) = (head? l).map f := by
   cases l <;> rfl
@@ -667,16 +651,11 @@ theorem tail_eq_tailD (l) : @tail α l = tailD l [] := by cases l <;> rfl
 
 theorem tail_eq_tail? (l) : @tail α l = (tail? l).getD [] := by simp [tail_eq_tailD]
 
-theorem tail_append_singleton_of_ne_nil {a : α} {l : List α} (h : l ≠ nil) :
-    tail (l ++ [a]) = tail l ++ [a] := by
-  induction l
-  · contradiction
-  · rw [tail, cons_append, tail]
+theorem tail_append_singleton_of_ne_nil {a : α} : ∀ {l}, l ≠ [] → tail (l ++ [a]) = tail l ++ [a]
+  | _::_, _ => rfl
 
-theorem tail_append_of_ne_nil (l l' : List α) (h : l ≠ []) : (l ++ l').tail = l.tail ++ l' := by
-  cases l
-  · contradiction
-  · simp
+theorem tail_append_of_ne_nil : ∀ (l l' : List α), l ≠ [] → (l ++ l').tail = l.tail ++ l' 
+  | _::_, _, _ => rfl
 
 /-! ### next? -/
 
@@ -724,7 +703,6 @@ theorem getLast?_eq_getLast : ∀ l h, @getLast? α l = some (getLast l h)
   | a :: b :: l => by simp [getLast?_isSome (l := b :: l)]
 
 theorem mem_getLast?_eq_getLast : ∀ {l : List α} {x : α}, x ∈ l.getLast? → ∃ h, x = getLast l h
-  | [], x, hx => False.elim <| by simp at hx
   | [a], x, hx =>
     have : a = x := by simpa using hx
     this ▸ ⟨cons_ne_nil a [], rfl⟩
@@ -735,12 +713,10 @@ theorem mem_getLast?_eq_getLast : ∀ {l : List α} {x : α}, x ∈ l.getLast? �
     assumption
 
 theorem getLast?_eq_getLast_of_ne_nil : ∀ {l : List α} (h : l ≠ []), l.getLast? = some (l.getLast h)
-  | [], h => (h rfl).elim
   | [_], _ => rfl
   | _ :: b :: l, _ => getLast?_eq_getLast_of_ne_nil (l := b :: l) (cons_ne_nil _ _)
 
 theorem mem_getLast?_cons {x y : α} : ∀ {l : List α}, x ∈ l.getLast? → x ∈ (y :: l).getLast?
-  | [], _ => by contradiction
   | _ :: _, h => h
 
 theorem mem_of_mem_getLast? {l : List α} {a : α} (ha : a ∈ l.getLast?) : a ∈ l :=
@@ -756,15 +732,10 @@ theorem mem_of_mem_getLast? {l : List α} {a : α} (ha : a ∈ l.getLast?) : a �
 
 theorem getLast?_append_of_ne_nil (l₁ : List α) :
     ∀ {l₂ : List α} (_ : l₂ ≠ []), getLast? (l₁ ++ l₂) = getLast? l₂
-  | [], hl₂ => by contradiction
   | b :: l₂, _ => getLast?_append_cons l₁ b l₂
 
-theorem getLast?_append {l₁ l₂ : List α} {x : α} (h : x ∈ l₂.getLast?) :
-    x ∈ (l₁ ++ l₂).getLast? := by
-  cases l₂
-  · contradiction
-  · rw [List.getLast?_append_cons]
-    exact h
+theorem getLast?_append : ∀ {l₁ l₂ : List α}, x ∈ l₂.getLast? → x ∈ (l₁ ++ l₂).getLast?
+  | _, _::_, h => getLast?_append_cons .. ▸ h
 
 /-! ### dropLast -/
 
@@ -937,10 +908,8 @@ theorem getLast?_eq_get? : ∀ (l : List α), getLast? l = l.get? (l.length - 1)
   | [], a => rfl
   | b :: l, a => by rw [cons_append, length_cons]; simp only [get?, get?_concat_length]
 
--- simp can prove this
--- @[simp]
 theorem getLast?_concat (l : List α) : getLast? (l ++ [a]) = some a := by
-  simp [getLast?_eq_get?]
+  simp
 
 @[simp] theorem getLastD_concat (a b l) : @getLastD α (l ++ [b]) a = b := by
   rw [getLastD_eq_getLast?, getLast?_concat]; rfl

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -687,26 +687,11 @@ theorem head!_mem_self [Inhabited α] {l : List α} (h : l ≠ nil) : l.head! �
 @[simp] theorem head?_map (f : α → β) (l) : head? (map f l) = (head? l).map f := by
   cases l <;> rfl
 
--- List.modifyHead_modifyHead.{u_1} Left-hand side simplifies from
---   List.modifyHead g (List.modifyHead f l)
--- to
---   match
---   match l with
---   | [] => []
---   | a :: l => f a :: l with
--- | [] => []
--- | a :: l => g a :: l
--- using
---   simp only [@List.modifyHead]
--- Try to change the left-hand side to the simplified term!
---
--- @[simp 1100]
+@[simp]
 theorem modifyHead_modifyHead (l : List α) (f g : α → α) :
     (l.modifyHead f).modifyHead g = l.modifyHead (g ∘ f) := by
-  cases l
-  · simp only [modifyHead]
-  · simp only [modifyHead]
-    rfl
+  cases l <;> simp only [modifyHead]
+  rfl
 
 /-! ### tail -/
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -369,10 +369,10 @@ theorem subset_singleton_iff {a : α} {L : List α} : L ⊆ [a] ↔ ∃ n, L = r
     map f (replicate n a) = replicate n (f a) := by
   induction n <;> [rfl; simp only [*, replicate, map]]
 
-@[simp] theorem tail_replicate (a : α) (n) :
+theorem tail_replicate (a : α) (n) :
     tail (replicate n a) = replicate (n - 1) a := by cases n <;> rfl
 
-@[simp] theorem join_replicate_nil (n : Nat) : join (replicate n []) = @nil α := by
+theorem join_replicate_nil (n : Nat) : join (replicate n []) = @nil α := by
   induction n <;> [rfl; simp only [*, replicate, join, append_nil]]
 
 /-! ### getLast -/
@@ -426,7 +426,7 @@ theorem getLast_mem {l : List α} (h : l ≠ []) : getLast l h ∈ l := by
     | nil => exact mem_singleton_self ..
     | cons _ _ =>
       rw [getLast_cons]
-      apply mem_cons_of_mem _ <| ih (cons_ne_nil _ _)
+      apply mem_cons_of_mem _ <| ih $ cons_ne_nil _ _
 
 theorem getLast_replicate_succ (m : Nat) (a : α) :
     (replicate (m + 1) a).getLast (ne_nil_of_length_eq_succ (length_replicate _ _)) = a := by

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -404,7 +404,7 @@ theorem eq_nil_or_concat : ∀ l : List α, l = [] ∨ ∃ L b, l = L ++ [b]
 
 theorem getLast_append_singleton {a : α} (l : List α) :
     getLast (l ++ [a]) (append_ne_nil_of_ne_nil_right l _ (cons_ne_nil a _)) = a := by
-  simp only [getLast_append]
+  simp
 
 -- Porting note: name should be fixed upstream
 theorem getLast_append' (l₁ l₂ : List α) (h : l₂ ≠ []) :

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -425,7 +425,7 @@ theorem getLast_mem {l : List α} (h : l ≠ []) : getLast l h ∈ l := by
     | nil => exact mem_singleton_self ..
     | cons _ _ =>
       rw [getLast_cons]
-      apply mem_cons_of_mem _ <| ih $ cons_ne_nil _ _
+      apply mem_cons_of_mem _ <| ih (cons_ne_nil _ _)
 
 theorem getLast_replicate_succ (m : Nat) (a : α) :
     (replicate (m + 1) a).getLast (ne_nil_of_length_eq_succ (length_replicate _ _)) = a := by

--- a/Std/Data/String/Lemmas.lean
+++ b/Std/Data/String/Lemmas.lean
@@ -237,7 +237,7 @@ theorem utf8SetAux_of_valid (c' : Char) (cs cs' : List Char) {i p : Nat} (hp : i
     utf8SetAux c' (cs ++ cs') ⟨i⟩ ⟨p⟩ = cs ++ cs'.modifyHead fun _ => c' := by
   match cs, cs' with
   | [], [] => rfl
-  | [], c::cs' => simp [← hp, utf8SetAux]
+  | [], c::cs' => simp [List.modifyHead, ← hp, utf8SetAux]
   | c::cs, cs' =>
     simp [utf8SetAux]; rw [if_neg]
     case hnc => simp [← hp, Pos.ext_iff]; exact ne_self_add_add_csize
@@ -740,7 +740,7 @@ theorem mapAux_of_valid (f : Char → Char) : ∀ l r, mapAux f ⟨utf8Len l⟩ 
   | l, c::r => by
     unfold mapAux
     rw [dif_neg (by rw [atEnd_of_valid]; simp)]
-    simp [set_of_valid l (c::r), get_of_valid l (c::r), next_of_valid l (f c) r]
+    simp [List.modifyHead, set_of_valid l (c::r), get_of_valid l (c::r), next_of_valid l (f c) r]
     simpa using mapAux_of_valid f (l++[f c]) r
 
 theorem map_eq (f : Char → Char) (s) : map f s = ⟨s.1.map f⟩ := by


### PR DESCRIPTION
Integrates a few of Mathlib's lemmas over `List`s. Some proofs have been slightly simplified