### PR TITLE
feat: add type classes for decidable < and <= relations

### DIFF
--- a/Std.lean
+++ b/Std.lean
@@ -1,5 +1,7 @@
 import Std.Classes.BEq
 import Std.Classes.Cast
+import Std.Classes.DecidableLE
+import Std.Classes.DecidableLT
 import Std.Classes.Dvd
 import Std.Classes.LawfulMonad
 import Std.Classes.Order

--- a/Std/Classes/DecidableLE.lean
+++ b/Std/Classes/DecidableLE.lean
@@ -1,0 +1,15 @@
+/--
+Asserts that the "less-than-or-equal" relation on `α` is decidable, that is, `a ≤ b` is decidable
+for all `a b : α`. See `Decidable`.
+
+It is generally not necessary to create instances of this class directly, because Lean will create
+one whenever a `DecidableRel` instance exists for the `LE` instance in question.
+-/
+class DecidableLE (α : Type u) extends LE α where
+  /-- Decide whether `x` is less than or equal to `y`. -/
+  decLE : (x y : α) → Decidable (LE.le x y)
+
+instance [DecidableLE α] {x y : α} : Decidable (x ≤ y) := DecidableLE.decLE _ _
+
+instance [inst : LE α] [DecidableRel (@LE.le α inst)] : DecidableLE α where
+  decLE := inferInstance

--- a/Std/Classes/DecidableLT.lean
+++ b/Std/Classes/DecidableLT.lean
@@ -1,0 +1,15 @@
+/--
+Asserts that the "less-than" relation on `α` is decidable, that is, `a < b` is decidable for all
+`a b : α`. See `Decidable`.
+
+It is generally not necessary to create instances of this class directly, because Lean will create
+one whenever a `DecidableRel` instance exists for the `LT` instance in question.
+-/
+class DecidableLT (α : Type u) extends LT α where
+  /-- Decide whether `x` is less than `y`. -/
+  decLT : (x y : α) → Decidable (LT.lt x y)
+
+instance [DecidableLT α] {x y : α} : Decidable (x < y) := DecidableLT.decLT _ _
+
+instance [inst : LT α] [DecidableRel (@LT.lt α inst)] : DecidableLT α where
+  decLT := inferInstance

--- a/test/decLE.lean
+++ b/test/decLE.lean
@@ -1,0 +1,69 @@
+import Std.Classes.DecidableLT
+import Std.Classes.DecidableLE
+import Std.Tactic.GuardMsgs
+import Std.Tactic.Omega
+
+inductive Three where
+  | one | two | three
+
+inductive ThreeLT : (a b : Three) → Prop where
+  | one : ThreeLT .one any
+  | two : ThreeLT .two .three
+
+instance : LT Three where
+  lt := ThreeLT
+
+instance : DecidableRel (@LT.lt Three _) := fun a b => by
+  cases a <;> cases b <;>
+  first
+    | apply isTrue ; constructor
+    | apply isFalse ; intro h ; cases h
+
+abbrev ThreeLE (a b : Three) : Prop := ThreeLT a b ∨ a = b
+
+instance : LE Three where
+  le := ThreeLE
+
+instance : DecidableRel (@LE.le Three _) := fun a b => by
+    cases a <;> cases b <;>
+  first
+    | apply isTrue
+      first
+        | apply Or.inr
+          rfl
+        | apply Or.inl
+          constructor
+    | apply isFalse
+      intro h
+      cases h with | _ h =>
+      cases h
+
+def insertSorted [DecidableLT α] (arr : Array α) (i : Fin arr.size) : Array α :=
+  match i with
+  | ⟨0, _⟩ => arr
+  | ⟨i' + 1, _⟩ =>
+    have : i' < arr.size := by omega
+    if arr[i'] < arr[i] then
+      arr
+    else
+      insertSorted
+        (arr.swap ⟨i', by assumption⟩ i)
+        ⟨i', by simp [*]⟩
+
+/-- info: #[1, 2, 3, 4, 5, 6] -/
+#guard_msgs in #eval insertSorted #[1,2,4,5,3,6] ⟨4, by decide⟩
+
+def insertSorted' [DecidableLE α] (arr : Array α) (i : Fin arr.size) : Array α :=
+  match i with
+  | ⟨0, _⟩ => arr
+  | ⟨i' + 1, _⟩ =>
+    have : i' < arr.size := by omega
+    if arr[i'] ≤ arr[i] then
+      arr
+    else
+      insertSorted'
+        (arr.swap ⟨i', by assumption⟩ i)
+        ⟨i', by simp [*]⟩
+
+/-- info: #[1, 2, 3, 4, 5, 6] -/
+#guard_msgs in #eval insertSorted' #[1,2,4,5,3,6] ⟨4, by decide⟩


### PR DESCRIPTION
This means that instead of writing
```
def f [inst : LT α] [DecidableRel (@LT.lt α inst)] (args ...) := ...
```
users can write
```
def f [DecidableLT α] (args ...) := ...
```
I find this much easier to figure out, and it doesn't impose any extra work on library authors.

This came up while @nomeata and I were writing code examples for a tutorial today.