### PR TITLE
Add specialized associative List folds

### DIFF
--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -258,7 +258,7 @@ where
 instance {α : Type _} : Std.Associative (α := List α) List.append where
   assoc := append_assoc
 
-instance {α : Type _} : Std.LawfulIdentity (α := List α) List.append nil where
+instance {α : Type _} : Std.LawfulIdentity (α := List α) (· ++ ·) [] where
   left_id := nil_append
   right_id := append_nil
 

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -298,8 +298,7 @@ Product of elements in a list.
 
 `List.prod [a, b, c] = ((1 * a) * b) * c`
 -/
-def prod {α} [Mul α] [One α] : List α → α := foldl (· * ·) 1
-
+def prod {α} [Mul α] [OfNat α 1] : List α → α := foldl (· * ·) 1
 
 /--
 `prodMap f l` returns `prod (map f l)` without creating an intermediate list.

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -280,7 +280,9 @@ def foldMap {α : Type _} {β : Type _} (op : β → β → β) {o : β} [Std.Le
   l.foldl (init := o) (fun b a => op b (f a))
 
 /--
-Sum of elements in list.
+Sum of elements in a list.
+
+`List.sum [a, b, c] = ((0 + a) + b) + c`
 -/
 def sum [Add α] [OfNat α 0] (l : List α) : α :=
   l.foldl (init := 0) (· + ·)
@@ -292,10 +294,12 @@ def sumMap {α : Type u} {β : Type v} [Add β] [OfNat β 0] (f : α → β) (l 
   l.foldl (init := 0) (· + f ·)
 
 /--
-Product of elements in list.
+Product of elements in a list.
+
+`List.prod [a, b, c] = ((1 * a) * b) * c`
 -/
-def prod [Mul α] [OfNat α 1] (l : List α) : α :=
-  l.foldl (init := 1) (· * ·)
+def prod {α} [Mul α] [One α] : List α → α := foldl (· * ·) 1
+
 
 /--
 `prodMap f l` returns `prod (map f l)` without creating an intermediate list.

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -255,7 +255,7 @@ where
 
 /-! ## Algebraic instances -/
 
-instance {α : Type _} : Std.Associative (α := List α) List.append where
+instance {α : Type _} : Std.Associative (α := List α) (· ++ ·) where
   assoc := append_assoc
 
 instance {α : Type _} : Std.LawfulIdentity (α := List α) (· ++ ·) [] where

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -253,6 +253,44 @@ where
     | _::_ => by simp [intercalateTR.go, go]
     simp [intersperse, go]
 
+/-! ## Algebraic instances -/
+
+instance {α : Type _} : Std.Associative (α := List α) List.append where
+  assoc := append_assoc
+
+instance {α : Type _} : Std.LawfulIdentity (α := List α) List.append nil where
+  left_id := nil_append
+  right_id := append_nil
+
+/-! ## Generic fold and sum operations. -/
+
+/--
+Applies a fold operation to join elements together.
+-/
+@[nolint unusedArguments] -- Std.LeftIdentity is needed for inference only.
+def fold {α : Type _} (op : α → α → α) {o : α} [Std.LeftIdentity op o] (l : List α) : α :=
+  l.foldl (init := o) op
+
+/--
+`foldMap op f l` is equivalent to `fold op (map f l)`.
+-/
+@[nolint unusedArguments] -- Std.LeftIdentity is needed for inference only.
+def foldMap {α : Type _} {β : Type _} (op : β → β → β) {o : β} [Std.LeftIdentity op o] (f : α → β)
+    (l : List α) : β :=
+  l.foldl (init := o) (fun b a => op b (f a))
+
+/--
+Returns sum of elements in list.
+-/
+def sum [Add α] [OfNat α 0] (l : List α) : α :=
+  l.foldl (init := 0) (· + ·)
+
+/--
+sumMap f l returns the sum of `sum (map f l)` without creating an intermediate list.
+-/
+def sumMap {α : Type u} {β : Type v} [Add β] [OfNat β 0] (f : α → β) (l : List α) : β :=
+  l.foldl (init := 0) (· + f ·)
+
 /-! ## New definitions -/
 
 /--

--- a/Std/Data/List/Basic.lean
+++ b/Std/Data/List/Basic.lean
@@ -280,16 +280,28 @@ def foldMap {α : Type _} {β : Type _} (op : β → β → β) {o : β} [Std.Le
   l.foldl (init := o) (fun b a => op b (f a))
 
 /--
-Returns sum of elements in list.
+Sum of elements in list.
 -/
 def sum [Add α] [OfNat α 0] (l : List α) : α :=
   l.foldl (init := 0) (· + ·)
 
 /--
-sumMap f l returns the sum of `sum (map f l)` without creating an intermediate list.
+`sumMap f l` returns `sum (map f l)` without creating an intermediate list.
 -/
 def sumMap {α : Type u} {β : Type v} [Add β] [OfNat β 0] (f : α → β) (l : List α) : β :=
   l.foldl (init := 0) (· + f ·)
+
+/--
+Product of elements in list.
+-/
+def prod [Mul α] [OfNat α 1] (l : List α) : α :=
+  l.foldl (init := 1) (· * ·)
+
+/--
+`prodMap f l` returns `prod (map f l)` without creating an intermediate list.
+-/
+def prodMap {α : Type u} {β : Type v} [Mul β] [OfNat β 1] (f : α → β) (l : List α) : β :=
+  l.foldl (init := 1) (· * f ·)
 
 /-! ## New definitions -/
 

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -375,26 +375,22 @@ theorem foldr_assoc (op : α → α → α) [h : Associative op] (a b : α) (l :
   | nil => simp
   | cons c l ind => simp [ind, h.assoc]
 
-@[simp]
-theorem fold_nil (op : α → α → α) [LeftIdentity op o] : fold op (@nil α) = o := rfl
+@[simp] theorem fold_nil (op : α → α → α) [LeftIdentity op o] : fold op (@nil α) = o := rfl
 
-@[simp]
-theorem fold_cons (op : α → α → α) [ha : Associative op] [hl : LawfulIdentity op o]
+@[simp] theorem fold_cons (op : α → α → α) [ha : Associative op] [hl : LawfulIdentity op o]
     (a : α) (l : List α) : fold op (a :: l) = op a (fold op l) := by
   unfold fold
   simp [foldl_cons]
   conv => lhs; rw [hl.left_id, ←hl.right_id a]
   simp [foldl_assoc, hl.left_id]
 
-@[simp]
-theorem fold_append (op : α → α → α) [ha : Associative op] [hl : LawfulIdentity op o]
+@[simp] theorem fold_append (op : α → α → α) [ha : Associative op] [hl : LawfulIdentity op o]
     (k l : List α) : fold op (k ++ l) = op (fold op k) (fold op l) := by
   induction k with
   | nil => simp [hl.left_id]
   | cons a k ind => simp [ind, ha.assoc]
 
-@[simp]
-theorem foldMap_is_fold_map (op : β → β → β) [LeftIdentity op o] (f : α → β) (l : List α) :
+@[simp] theorem foldMap_is_fold_map (op : β → β → β) [LeftIdentity op o] (f : α → β) (l : List α) :
     foldMap op f l = fold op (map f l) := by
   unfold foldMap fold
   generalize (o : β) = init
@@ -402,8 +398,7 @@ theorem foldMap_is_fold_map (op : β → β → β) [LeftIdentity op o] (f : α 
   | nil => rfl
   | cons a l ind => simp [ind]
 
-@[simp]
-theorem sumMap_is_sum_map [Add β] [OfNat β 0] (f : α → β) (l : List α) :
+@[simp] theorem sumMap_is_sum_map [Add β] [OfNat β 0] (f : α → β) (l : List α) :
     sumMap f l = sum (map f l) := by
   unfold sumMap sum
   generalize (0 : β) = init
@@ -411,11 +406,9 @@ theorem sumMap_is_sum_map [Add β] [OfNat β 0] (f : α → β) (l : List α) :
   | nil => rfl
   | cons a l ind => simp [ind]
 
-@[simp]
-theorem sum_nil [Add α] [OfNat α 0] : sum (@nil α) = 0 := rfl
+@[simp] theorem sum_nil [Add α] [OfNat α 0] : sum (@nil α) = 0 := rfl
 
-@[simp]
-theorem sum_cons [Add α] [h : OfNat α 0]
+@[simp] theorem sum_cons [Add α] [h : OfNat α 0]
     [ha : Associative (α := α) (· + ·)] [hl : LawfulIdentity (α := α) (· + ·) 0]
     (a : α) (l : List α) : sum (a :: l) = a + sum l := by
   unfold sum
@@ -423,16 +416,14 @@ theorem sum_cons [Add α] [h : OfNat α 0]
   conv => lhs; rw [hl.left_id, ←hl.right_id a]
   simp [foldl_assoc, hl.left_id]
 
-@[simp]
-theorem sum_append [Add α] [OfNat α 0]
-    [ha : Associative (α := α) (· + ·)]  [hl : LawfulIdentity (α := α) (· + ·) 0]
+@[simp] theorem sum_append [Add α] [OfNat α 0]
+    [ha : Associative (α := α) (· + ·)] [hl : LawfulIdentity (α := α) (· + ·) 0]
     (k l : List α) : sum (k ++ l) = sum k + sum l := by
   induction k with
   | nil => simp [hl.left_id]
   | cons a k ind => simp [ind, ha.assoc]
 
-@[simp]
-theorem prodMap_is_prod_map [Mul β] [OfNat β 1] (f : α → β) (l : List α) :
+@[simp] theorem prodMap_is_prod_map [Mul β] [OfNat β 1] (f : α → β) (l : List α) :
     prodMap f l = prod (map f l) := by
   unfold prodMap prod
   generalize (1 : β) = init
@@ -440,11 +431,9 @@ theorem prodMap_is_prod_map [Mul β] [OfNat β 1] (f : α → β) (l : List α) 
   | nil => rfl
   | cons a l ind => simp [ind]
 
-@[simp]
-theorem prod_nil [Mul α] [OfNat α 1] : prod (@nil α) = 1 := rfl
+@[simp] theorem prod_nil [Mul α] [OfNat α 1] : prod (@nil α) = 1 := rfl
 
-@[simp]
-theorem prod_cons [Mul α] [h : OfNat α 1]
+@[simp] theorem prod_cons [Mul α] [h : OfNat α 1]
     [ha : Associative (α := α) (· * ·)] [hl : LawfulIdentity (α := α) (· * ·) 1]
     (a : α) (l : List α) : prod (a :: l) = a * prod l := by
   unfold prod
@@ -452,8 +441,7 @@ theorem prod_cons [Mul α] [h : OfNat α 1]
   conv => lhs; rw [hl.left_id, ←hl.right_id a]
   simp [foldl_assoc, hl.left_id]
 
-@[simp]
-theorem prod_append [Mul α] [OfNat α 1]
+@[simp] theorem prod_append [Mul α] [OfNat α 1]
     [ha : Associative (α := α) (· * ·)]  [hl : LawfulIdentity (α := α) (· * ·) 1]
     (k l : List α) : prod (k ++ l) = prod k * prod l := by
   induction k with
@@ -462,8 +450,7 @@ theorem prod_append [Mul α] [OfNat α 1]
 
 /-! ### join -/
 
-@[simp]
-theorem length_join (l : List (List α)) : length (join l) = sum (map length l) := by
+@[simp] theorem length_join (l : List (List α)) : length (join l) = sum (map length l) := by
   induction l with
   | nil => simp
   | cons a l ind => simp [ind]

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -358,7 +358,7 @@ theorem map_snd_zip :
     show _ :: map Prod.snd (zip as bs) = _ :: bs
     rw [map_snd_zip as bs h]
 
-/-! ### folds and sum -/
+/-! ### folds, sum and prod -/
 
 -- Allow moving an associative operation outside the left-fold.
 theorem foldl_assoc (op : α → α → α) [h : Std.Associative op] (a b : α) (l : List α) :
@@ -427,6 +427,35 @@ theorem sum_cons [Add α] [h : OfNat α 0]
 theorem sum_append [Add α] [OfNat α 0]
     [ha : Associative (α := α) (· + ·)]  [hl : LawfulIdentity (α := α) (· + ·) 0]
     (k l : List α) : sum (k ++ l) = sum k + sum l := by
+  induction k with
+  | nil => simp [hl.left_id]
+  | cons a k ind => simp [ind, ha.assoc]
+
+@[simp]
+theorem prodMap_is_prod_map [Mul β] [OfNat β 1] (f : α → β) (l : List α) :
+    prodMap f l = prod (map f l) := by
+  unfold prodMap prod
+  generalize (1 : β) = init
+  induction l generalizing init with
+  | nil => rfl
+  | cons a l ind => simp [ind]
+
+@[simp]
+theorem prod_nil [Mul α] [OfNat α 1] : prod (@nil α) = 1 := rfl
+
+@[simp]
+theorem prod_cons [Mul α] [h : OfNat α 1]
+    [ha : Associative (α := α) (· * ·)] [hl : Std.LawfulIdentity (α := α) (· * ·) 1]
+    (a : α) (l : List α) : prod (a :: l) = a * prod l := by
+  unfold prod
+  simp [foldl_cons]
+  conv => lhs; rw [hl.left_id, ←hl.right_id a]
+  simp [foldl_assoc, hl.left_id]
+
+@[simp]
+theorem prod_append [Mul α] [OfNat α 1]
+    [ha : Associative (α := α) (· * ·)]  [hl : LawfulIdentity (α := α) (· * ·) 1]
+    (k l : List α) : prod (k ++ l) = prod k * prod l := by
   induction k with
   | nil => simp [hl.left_id]
   | cons a k ind => simp [ind, ha.assoc]

--- a/Std/Data/List/Lemmas.lean
+++ b/Std/Data/List/Lemmas.lean
@@ -360,20 +360,20 @@ theorem map_snd_zip :
 
 /-! ### folds, sum and prod -/
 
+open Std
+
 -- Allow moving an associative operation outside the left-fold.
-theorem foldl_assoc (op : α → α → α) [h : Std.Associative op] (a b : α) (l : List α) :
+theorem foldl_assoc (op : α → α → α) [h : Associative op] (a b : α) (l : List α) :
     foldl op (op a b) l = op a (foldl op b l) := by
   induction l generalizing a b with
   | nil => simp
   | cons c l ind => simp [ind, h.assoc]
 
-theorem foldr_assoc (op : α → α → α) [h : Std.Associative op] (a b : α) (l : List α) :
+theorem foldr_assoc (op : α → α → α) [h : Associative op] (a b : α) (l : List α) :
     foldr op (op a b) l = op (foldr op a l) b := by
   induction l generalizing a b with
   | nil => simp
   | cons c l ind => simp [ind, h.assoc]
-
-open Std
 
 @[simp]
 theorem fold_nil (op : α → α → α) [LeftIdentity op o] : fold op (@nil α) = o := rfl
@@ -416,7 +416,7 @@ theorem sum_nil [Add α] [OfNat α 0] : sum (@nil α) = 0 := rfl
 
 @[simp]
 theorem sum_cons [Add α] [h : OfNat α 0]
-    [ha : Associative (α := α) (· + ·)] [hl : Std.LawfulIdentity (α := α) (· + ·) 0]
+    [ha : Associative (α := α) (· + ·)] [hl : LawfulIdentity (α := α) (· + ·) 0]
     (a : α) (l : List α) : sum (a :: l) = a + sum l := by
   unfold sum
   simp [foldl_cons]
@@ -445,7 +445,7 @@ theorem prod_nil [Mul α] [OfNat α 1] : prod (@nil α) = 1 := rfl
 
 @[simp]
 theorem prod_cons [Mul α] [h : OfNat α 1]
-    [ha : Associative (α := α) (· * ·)] [hl : Std.LawfulIdentity (α := α) (· * ·) 1]
+    [ha : Associative (α := α) (· * ·)] [hl : LawfulIdentity (α := α) (· * ·) 1]
     (a : α) (l : List α) : prod (a :: l) = a * prod l := by
   unfold prod
   simp [foldl_cons]

--- a/Std/Data/Nat/Lemmas.lean
+++ b/Std/Data/Nat/Lemmas.lean
@@ -9,6 +9,7 @@ import Std.Tactic.RCases
 import Std.Data.Nat.Init.Lemmas
 import Std.Data.Nat.Init.Dvd
 import Std.Data.Nat.Basic
+import Std.Data.Nat.Init.Lemmas
 import Std.Data.Ord
 
 /-! # Basic lemmas about natural numbers
@@ -140,6 +141,26 @@ theorem recDiagOn_succ_succ {motive : Nat → Nat → Sort _} (zero_zero : motiv
     (zero_succ : ∀ n, motive 0 (n+1)) (succ_zero : ∀ m, motive (m+1) 0)
     (succ_succ : ∀ m n, motive (m+1) (n+1)) (m n) :
     Nat.casesDiagOn (m+1) (n+1) zero_zero zero_succ succ_zero succ_succ = succ_succ m n := rfl
+
+/-! ### Associative and commutative instance. -/
+
+instance : Std.Associative (α := Nat) (· + ·) where
+  assoc := Nat.add_assoc
+
+instance : Std.Commutative (α := Nat) (· + ·) where
+  comm := Nat.add_comm
+
+instance : Std.LawfulCommIdentity (α := Nat) (· + ·) 0 where
+  right_id := Nat.add_zero
+
+instance : Std.Associative (α := Nat) (· * ·) where
+  assoc := Nat.mul_assoc
+
+instance : Std.Commutative (α := Nat) (· * ·) where
+  comm := Nat.mul_comm
+
+instance : Std.LawfulCommIdentity (α := Nat) (· * ·) 1 where
+  right_id := Nat.mul_one
 
 /-! ### le/lt -/
 


### PR DESCRIPTION
This uses the associativity, commutativity and identity classes recently added to Lean core to define folds with simplification lemmas that can move intermediate results outside the fold for better use in tactics.