### PR TITLE
chore: deprecations in dot notation

### DIFF
--- a/Batteries/Data/Array/Basic.lean
+++ b/Batteries/Data/Array/Basic.lean
@@ -195,7 +195,7 @@ subarray, or `none` if the subarray is empty.
 def popHead? (as : Subarray α) : Option (α × Subarray α) :=
   if h : as.start < as.stop
     then
-      let head := as.as.get ⟨as.start, Nat.lt_of_lt_of_le h as.h₂⟩
+      let head := as.array.get ⟨as.start, Nat.lt_of_lt_of_le h as.stop_le_array_size⟩
       let tail :=
         { as with
           start := as.start + 1


### PR DESCRIPTION
In preparation for https://github.com/leanprover/lean4/pull/3969 landing, we fix some deprecation warnings.