### PR TITLE
chore: align `isInternalName` with upstream version

### DIFF
--- a/Batteries/Lean/Name.lean
+++ b/Batteries/Lean/Name.lean
@@ -23,5 +23,6 @@ def isInternalDetail : Name → Bool
   | .num _ _     => true
   | p            => p.isInternalOrNum
 where
+  /-- Check that a string begins with the given prefix, and then is only digit characters. -/
   matchPrefix (s : String) (pre : String) :=
     s.startsWith pre && (s |>.drop pre.length |>.all Char.isDigit)

--- a/Batteries/Lean/Name.lean
+++ b/Batteries/Lean/Name.lean
@@ -16,8 +16,12 @@ Generally, user code should not explicitly use internal names.
 def isInternalDetail : Name → Bool
   | .str p s     =>
     s.startsWith "_"
-      || s.startsWith "match_"
-      || s.startsWith "proof_"
+      || matchPrefix s "eq_"
+      || matchPrefix s "match_"
+      || matchPrefix s "proof_"
       || p.isInternalOrNum
   | .num _ _     => true
   | p            => p.isInternalOrNum
+where
+  matchPrefix (s : String) (pre : String) :=
+    s.startsWith pre && (s |>.drop pre.length |>.all Char.isDigit)


### PR DESCRIPTION
There is another private copy of `isInternalName` up in lean. This makes the implementations identical.

Later I will move the upstream copy to `Lean.Name` and then remove this. 