### PR TITLE
fix: support `since` in `@[deprecated] alias`

### DIFF
--- a/Batteries/Tactic/Alias.lean
+++ b/Batteries/Tactic/Alias.lean
@@ -63,9 +63,11 @@ def setDeprecatedTarget (target : Name) (arr : Array Attribute) : Array Attribut
   StateT.run (m := Id) (s := false) do
     arr.mapM fun s => do
       if s.name == `deprecated then
-        if let `(deprecated| deprecated%$tk) := s.stx then
+        if let `(deprecated| deprecated%$tk $[$desc:str]? $[(since := $since)]?) := s.stx then
           set true
-          pure { s with stx := Unhygienic.run `(deprecated| deprecated%$tk $(mkCIdent target)) }
+          let stx := Unhygienic.run
+            `(deprecated| deprecated%$tk $(mkCIdent target) $[$desc:str]? $[(since := $since)]?)
+          pure { s with stx }
         else pure s
       else pure s
 

--- a/test/alias.lean
+++ b/test/alias.lean
@@ -13,12 +13,15 @@ theorem foo : 1 + 1 = 2 := rfl
 alias foo1 := foo
 @[deprecated] alias foo2 := foo
 @[deprecated foo2] alias _root_.B.foo3 := foo
+@[deprecated foo2 "it was never a good idea anyway" (since := "last thursday")] alias foo4 := foo
 
 example : 1 + 1 = 2 := foo1
 /-- warning: `A.foo2` has been deprecated, use `A.foo` instead -/
 #guard_msgs in example : 1 + 1 = 2 := foo2
 /-- warning: `B.foo3` has been deprecated, use `A.foo2` instead -/
 #guard_msgs in example : 1 + 1 = 2 := B.foo3
+/-- warning: it was never a good idea anyway -/
+#guard_msgs in example : 1 + 1 = 2 := foo4
 
 /-- doc string for bar -/
 def bar : Nat := 5


### PR DESCRIPTION
As [reported on Zulip](https://leanprover.zulipchat.com/#narrow/stream/348111-batteries/topic/Bad.20interaction.20of.20alias.20and.20deprecated.20.28since.20.3A.3D.20_.29/near/439757782).