### PR TITLE
feat: `measureRec` for strong induction use cases

### DIFF
--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -29,6 +29,15 @@ protected def strongRecOn (t : Nat) {motive : Nat → Sort _}
   (ind : ∀ n, (∀ m, m < n → motive m) → motive n) : motive t := Nat.strongRec ind t
 
 /--
+  Strong recursor via a `Nat`-valued measure
+-/
+@[elab_as_elim]
+def strongRecMeasure (f : α → Nat) {motive : α → Sort _}
+    (ind : ∀ x, (∀ y, f y < f x → motive y) → motive x) (x : α) : motive x :=
+  ind x fun y _ => strongRecMeasure f ind y
+termination_by f x
+
+/--
   Simple diagonal recursor for `Nat`
 -/
 @[elab_as_elim]

--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -29,6 +29,15 @@ protected def strongRecOn (t : Nat) {motive : Nat → Sort _}
   (ind : ∀ n, (∀ m, m < n → motive m) → motive n) : motive t := Nat.strongRec ind t
 
 /--
+  Strong recursor via `Nat`-valued measure
+-/
+@[elab_as_elim]
+protected def strongRecMeasureOn (f : α → Nat) (x : α) {motive : α → Sort _}
+    (ind : ∀ x, (∀ y, f y < f x → motive y) → motive x) : motive x :=
+  ind x fun y _ => Nat.strongRecMeasureOn f y ind
+termination_by f x
+
+/--
   Simple diagonal recursor for `Nat`
 -/
 @[elab_as_elim]

--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -29,15 +29,6 @@ protected def strongRecOn (t : Nat) {motive : Nat → Sort _}
   (ind : ∀ n, (∀ m, m < n → motive m) → motive n) : motive t := Nat.strongRec ind t
 
 /--
-  Strong recursor via `Nat`-valued measure
--/
-@[elab_as_elim]
-protected def strongRecMeasureOn (f : α → Nat) (x : α) {motive : α → Sort _}
-    (ind : ∀ x, (∀ y, f y < f x → motive y) → motive x) : motive x :=
-  ind x fun y _ => Nat.strongRecMeasureOn f y ind
-termination_by f x
-
-/--
   Simple diagonal recursor for `Nat`
 -/
 @[elab_as_elim]

--- a/Batteries/WF.lean
+++ b/Batteries/WF.lean
@@ -7,7 +7,7 @@ Authors: Miyahara Kō
 /-!
 # Computable Acc.rec and WellFounded.fix
 
-By importing this file, the compiler will
+This file exports no public definitions / theorems, but by importing it the compiler will
 be able to compile `Acc.rec` and functions that use it. For example:
 
 Before:
@@ -36,26 +36,6 @@ def log2p1 : Nat → Nat := -- works!
       0
 
 #eval log2p1 4   -- 3
-```
-
-# `measureRec`
-
-`measureRec` provides the `induction` tactic with an analogue to
-`termination_by` a `Nat`-valued measure. For example:
-```lean
-import Batteries.WF
-
-example (l : List α) : sorry := by
-  induction l using measureRec List.length with
-  | ind l ih => exact ih sorry sorry
-```
-is analogous to:
-```lean
-example (l : List α) : sorry := by
-  let rec proof (l : List α) : sorry := proof sorry
-  termination_by List.length l
-  decreasing_by sorry
-  exact proof l
 ```
 -/
 
@@ -147,15 +127,3 @@ unseal fixC
 @[csimp] private theorem fix_eq_fixC : @fix = @fixC := rfl
 
 end WellFounded
-
-/--
-Strong recursor via a `Nat`-valued measure.
-
-Note that for non-`Prop` output it is preferable to use the equation compiler
-directly if possible, since this produces equation lemmas.
--/
-@[elab_as_elim]
-def measureRec (f : α → Nat) {motive : α → Sort _}
-    (ind : ∀ x, (∀ y, f y < f x → motive y) → motive x) (x : α) : motive x :=
-  ind x fun y _ => measureRec f ind y
-termination_by f x


### PR DESCRIPTION
This is from @nomeata's Zulip comment: https://leanprover.zulipchat.com/#narrow/stream/113489-new-members/topic/Contributing.20a.20strong.20induction.20for.20lists/near/442796959. It can subsume, for example, mathlib's `Finset.strongInductionOn` and `Multiset.strongInductionOn`.

In situations where it doesn't make sense to extract a goal into a top-level `theorem`/`def`, `induction _ using measureRec` will be more convenient than `let rec` -> `termination_by` -> `decreasing_by` -> `exact`.