### PR TITLE
refactor(linter): move `addMessageContext` to top level

### DIFF
--- a/Batteries/Tactic/Lint/Frontend.lean
+++ b/Batteries/Tactic/Lint/Frontend.lean
@@ -125,11 +125,9 @@ def printWarning (declName : Name) (warning : MessageData) (useErrorFormat : Boo
   (filePath : System.FilePath := default) : CoreM MessageData := do
   if useErrorFormat then
     if let some range ← findDeclarationRanges? declName then
-      let msg ← addMessageContextPartial
-        m!"{filePath}:{range.range.pos.line}:{range.range.pos.column + 1}: error: {
+      return m!"{filePath}:{range.range.pos.line}:{range.range.pos.column + 1}: error: {
           ← mkConstWithLevelParams declName} {warning}"
-      return msg
-  addMessageContextPartial m!"#check {← mkConstWithLevelParams declName} /- {warning} -/"
+  pure m!"#check {← mkConstWithLevelParams declName} /- {warning} -/"
 
 /-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/
 def printWarnings (results : HashMap Name MessageData) (filePath : System.FilePath := default)

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -72,7 +72,7 @@ unsafe def main (args : List String) : IO Unit := do
         let fmtResults ←
           formatLinterResults results decls (groupByFilename := true) (useErrorFormat := true)
             s!"in {module}" (runSlowLinters := true) .medium linters.size
-        IO.print (← fmtResults.toString)
+        IO.print (← (← addMessageContext fmtResults).toString)
         IO.Process.exit 1
       else
         IO.println "-- Linting passed."


### PR DESCRIPTION
Follow-up to #838, I think this is a slightly better place to inject the message context as it will cover everything in the message.