### PR TITLE
chore: adaptations for leanprover/lean4#4400, List look-up normal form

### DIFF
--- a/Batteries/Data/Array/Lemmas.lean
+++ b/Batteries/Data/Array/Lemmas.lean
@@ -64,7 +64,7 @@ theorem zipWith_eq_zipWith_data (f : α → β → γ) (as : Array α) (bs : Arr
       let i_bs : Fin bs.data.length := ⟨i, hbs⟩
       rw [h₁, List.append_assoc]
       congr
-      rw [← List.zipWith_append (h := by simp), getElem_eq_data_get, getElem_eq_data_get]
+      rw [← List.zipWith_append (h := by simp), getElem_eq_data_getElem, getElem_eq_data_getElem]
       show List.zipWith f ((List.get as.data i_as) :: List.drop (i_as + 1) as.data)
         ((List.get bs.data i_bs) :: List.drop (i_bs + 1) bs.data) =
         List.zipWith f (List.drop i as.data) (List.drop i bs.data)

--- a/Batteries/Data/Array/Lemmas.lean
+++ b/Batteries/Data/Array/Lemmas.lean
@@ -22,7 +22,7 @@ theorem forIn_eq_data_forIn [Monad m]
       have j_eq : j = size as - 1 - i := by simp [← ij, ← Nat.add_assoc]
       have : as.size - 1 - i < as.size := j_eq ▸ ij ▸ Nat.lt_succ_of_le (Nat.le_add_right ..)
       have : as[size as - 1 - i] :: as.data.drop (j + 1) = as.data.drop j := by
-        rw [j_eq]; exact List.get_cons_drop _ ⟨_, this⟩
+        rw [j_eq]; exact List.getElem_cons_drop _ _ this
       simp only [← this, List.forIn_cons]; congr; funext x; congr; funext b
       rw [loop (i := i)]; rw [← ij, Nat.succ_add]; rfl
   conv => lhs; simp only [forIn, Array.forIn]
@@ -65,11 +65,10 @@ theorem zipWith_eq_zipWith_data (f : α → β → γ) (as : Array α) (bs : Arr
       rw [h₁, List.append_assoc]
       congr
       rw [← List.zipWith_append (h := by simp), getElem_eq_data_getElem, getElem_eq_data_getElem]
-      show List.zipWith f ((List.get as.data i_as) :: List.drop (i_as + 1) as.data)
+      show List.zipWith f (as.data[i_as] :: List.drop (i_as + 1) as.data)
         ((List.get bs.data i_bs) :: List.drop (i_bs + 1) bs.data) =
         List.zipWith f (List.drop i as.data) (List.drop i bs.data)
-      simp only [List.get_cons_drop]
-    termination_by as.size - i
+      simp only [data_length, Fin.getElem_fin, List.getElem_cons_drop, List.get_eq_getElem]
   simp [zipWith, loop 0 #[] (by simp) (by simp)]
 
 theorem size_zipWith (as : Array α) (bs : Array β) (f : α → β → γ) :

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -30,8 +30,12 @@ protected theorem le_antisymm {x y : Fin n} (h1 : x ≤ y) (h2 : y ≤ x) : x = 
 
 @[simp] theorem length_list (n) : (list n).length = n := by simp [list]
 
-@[simp] theorem get_list (i : Fin (list n).length) : (list n).get i = i.cast (length_list n) := by
-  cases i; simp only [list]; rw [← Array.getElem_eq_data_get, getElem_enum, cast_mk]
+@[simp] theorem getElem_list (i : Nat) (h : i < (list n).length) :
+    (list n)[i] = cast (length_list n) ⟨i, h⟩ := by
+  simp only [list]; rw [← Array.getElem_eq_data_getElem, getElem_enum, cast_mk]
+
+theorem get_list (i : Fin (list n).length) : (list n).get i = i.cast (length_list n) := by
+  simp [getElem_list]
 
 @[simp] theorem list_zero : list 0 = [] := by simp [list]
 

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -34,6 +34,7 @@ protected theorem le_antisymm {x y : Fin n} (h1 : x ≤ y) (h2 : y ≤ x) : x = 
     (list n)[i] = cast (length_list n) ⟨i, h⟩ := by
   simp only [list]; rw [← Array.getElem_eq_data_getElem, getElem_enum, cast_mk]
 
+@[deprecated getElem_list (since := "2024-06-12")]
 theorem get_list (i : Fin (list n).length) : (list n).get i = i.cast (length_list n) := by
   simp [getElem_list]
 

--- a/Batteries/Data/HashMap/WF.lean
+++ b/Batteries/Data/HashMap/WF.lean
@@ -23,7 +23,7 @@ theorem update_data (self : Buckets α β) (i d h) :
 theorem exists_of_update (self : Buckets α β) (i d h) :
     ∃ l₁ l₂, self.1.data = l₁ ++ self.1[i] :: l₂ ∧ List.length l₁ = i.toNat ∧
       (self.update i d h).1.data = l₁ ++ d :: l₂ := by
-  simp only [Array.data_length, Array.ugetElem_eq_getElem, Array.getElem_eq_data_get]
+  simp only [Array.data_length, Array.ugetElem_eq_getElem, Array.getElem_eq_data_getElem]
   exact List.exists_of_set' h
 
 theorem update_update (self : Buckets α β) (i d d' h h') :
@@ -43,7 +43,7 @@ theorem WF.mk' [BEq α] [Hashable α] (h) : (Buckets.mk n h : Buckets α β).WF 
   refine ⟨fun _ h => ?_, fun i h => ?_⟩
   · simp only [Buckets.mk, mkArray, List.mem_replicate, ne_eq] at h
     simp [h, List.Pairwise.nil]
-  · simp [Buckets.mk, empty', mkArray, Array.getElem_eq_data_get, AssocList.All]
+  · simp [Buckets.mk, empty', mkArray, Array.getElem_eq_data_getElem, AssocList.All]
 
 theorem WF.update [BEq α] [Hashable α] {buckets : Buckets α β} {i d h} (H : buckets.WF)
     (h₁ : ∀ [PartialEquivBEq α] [LawfulHashable α],
@@ -57,7 +57,8 @@ theorem WF.update [BEq α] [Hashable α] {buckets : Buckets α β} {i d h} (H : 
     | .inl hl => H.1 _ hl
     | .inr rfl => h₁ (H.1 _ (Array.getElem_mem_data ..))
   · revert hp
-    simp only [Array.getElem_eq_data_get, update_data, List.get_set, Array.data_length, update_size]
+    simp only [Array.getElem_eq_data_getElem, update_data, List.getElem_set, Array.data_length,
+      update_size]
     split <;> intro hp
     · next eq => exact eq ▸ h₂ (H.2 _ _) _ hp
     · simp only [update_size, Array.data_length] at hi
@@ -81,6 +82,7 @@ theorem reinsertAux_WF [BEq α] [Hashable α] {data : Buckets α β} {a : α} {b
     | _, _, .head .. => rfl
     | H, _, .tail _ h => H _ h
 
+set_option linter.deprecated false in
 theorem expand_size [Hashable α] {buckets : Buckets α β} :
     (expand sz buckets).buckets.size = buckets.size := by
   rw [expand, go]
@@ -166,8 +168,8 @@ where
       · match List.mem_or_eq_of_mem_set hl with
         | .inl hl => exact hs₁ _ hl
         | .inr e => exact e ▸ .nil
-      · simp only [Array.data_length, Array.size_set, Array.getElem_eq_data_get, Array.data_set,
-          List.get_set]
+      · simp only [Array.data_length, Array.size_set, Array.getElem_eq_data_getElem, Array.data_set,
+          List.getElem_set]
         split
         · nofun
         · exact hs₂ _ (by simp_all)
@@ -362,8 +364,8 @@ theorem WF.filterMap {α β γ} {f : α → β → Option γ} [BEq α] [Hashable
     have := H.out.2.1 _ h
     rw [← List.pairwise_map (R := (¬ · == ·))] at this ⊢
     exact this.sublist (H3 l.toList)
-  · simp only [Array.size_mk, List.length_map, Array.data_length, Array.getElem_eq_data_get,
-      List.get_map] at h ⊢
+  · simp only [Array.size_mk, List.length_map, Array.data_length, Array.getElem_eq_data_getElem,
+      List.getElem_map] at h ⊢
     have := H.out.2.2 _ h
     simp only [AssocList.All, List.toList_toAssocList, List.mem_reverse, List.mem_filterMap,
       Option.map_eq_some', forall_exists_index, and_imp, g₁] at this ⊢

--- a/Batteries/Data/HashMap/WF.lean
+++ b/Batteries/Data/HashMap/WF.lean
@@ -101,7 +101,7 @@ where
       · case b =>
         refine have ⟨l₁, l₂, h₁, _, eq⟩ := List.exists_of_set' H; eq ▸ ?_
         simp only [Buckets.size_eq, h₁, List.map_append, List.map_cons, AssocList.toList,
-          List.length_nil, Nat.sum_append, Nat.sum_cons, Nat.zero_add,  Array.data_length]
+          List.length_nil, Nat.sum_append, Nat.sum_cons, Nat.zero_add, Array.data_length]
         rw [Nat.add_assoc, Nat.add_assoc, Nat.add_assoc]; congr 1
         (conv => rhs; rw [Nat.add_left_comm]); congr 1
         rw [List.get_eq_getElem, ← Array.getElem_eq_data_getElem]

--- a/Batteries/Data/HashMap/WF.lean
+++ b/Batteries/Data/HashMap/WF.lean
@@ -87,15 +87,15 @@ theorem expand_size [Hashable α] {buckets : Buckets α β} :
   · rw [Buckets.mk_size]; simp [Buckets.size]
   · nofun
 where
-  go (i source) (target : Buckets α β) (hs : ∀ j < i, source.data.getD j .nil = .nil) :
+  go (i source) (target : Buckets α β) (hs : ∀ j < i, source.data[j]?.getD .nil = .nil) :
       (expand.go i source target).size =
         .sum (source.data.map (·.toList.length)) + target.size := by
     unfold expand.go; split
     · next H =>
       refine (go (i+1) _ _ fun j hj => ?a).trans ?b <;> simp
       · case a =>
-        simp only [List.getD_eq_get?, List.get?_set, Option.map_eq_map]; split
-        · cases List.get? .. <;> rfl
+        simp [List.getD_eq_get?, List.getElem?_set, Option.map_eq_map]; split
+        · cases source.data[j]? <;> rfl
         · next H => exact hs _ (Nat.lt_of_le_of_ne (Nat.le_of_lt_succ hj) (Ne.symm H))
       · case b =>
         refine have ⟨l₁, l₂, h₁, _, eq⟩ := List.exists_of_set' H; eq ▸ ?_
@@ -114,7 +114,7 @@ where
       refine List.ext_get (by simp) fun j h₁ h₂ => ?_
       simp only [List.get_map, Array.data_length]
       have := (hs j (Nat.lt_of_lt_of_le h₂ (Nat.not_lt.1 H))).symm
-      rwa [List.getD_eq_get?, List.get?_eq_get, Option.getD_some] at this
+      rwa [List.getElem?_eq_getElem] at this
   termination_by source.size - i
 
 theorem expand_WF.foldl [BEq α] [Hashable α] (rank : α → Nat) {l : List (α × β)} {i : Nat}

--- a/Batteries/Data/HashMap/WF.lean
+++ b/Batteries/Data/HashMap/WF.lean
@@ -100,7 +100,8 @@ where
         · next H => exact hs _ (Nat.lt_of_le_of_ne (Nat.le_of_lt_succ hj) (Ne.symm H))
       · case b =>
         refine have ⟨l₁, l₂, h₁, _, eq⟩ := List.exists_of_set' H; eq ▸ ?_
-        simp only [Buckets.size_eq, h₁, List.map_append, List.map_cons, AssocList.toList,
+        rw [h₁]
+        simp only [Buckets.size_eq, List.map_append, List.map_cons, AssocList.toList,
           List.length_nil, Nat.sum_append, Nat.sum_cons, Nat.zero_add, Array.data_length]
         rw [Nat.add_assoc, Nat.add_assoc, Nat.add_assoc]; congr 1
         (conv => rhs; rw [Nat.add_left_comm]); congr 1

--- a/Batteries/Data/HashMap/WF.lean
+++ b/Batteries/Data/HashMap/WF.lean
@@ -82,7 +82,6 @@ theorem reinsertAux_WF [BEq α] [Hashable α] {data : Buckets α β} {a : α} {b
     | _, _, .head .. => rfl
     | H, _, .tail _ h => H _ h
 
-set_option linter.deprecated false in
 theorem expand_size [Hashable α] {buckets : Buckets α β} :
     (expand sz buckets).buckets.size = buckets.size := by
   rw [expand, go]
@@ -96,7 +95,7 @@ where
     · next H =>
       refine (go (i+1) _ _ fun j hj => ?a).trans ?b <;> simp
       · case a =>
-        simp [List.getD_eq_get?, List.getElem?_set, Option.map_eq_map]; split
+        simp [List.getD_eq_getElem?, List.getElem?_set, Option.map_eq_map]; split
         · cases source.data[j]? <;> rfl
         · next H => exact hs _ (Nat.lt_of_le_of_ne (Nat.le_of_lt_succ hj) (Ne.symm H))
       · case b =>
@@ -105,7 +104,7 @@ where
           List.length_nil, Nat.sum_append, Nat.sum_cons, Nat.zero_add,  Array.data_length]
         rw [Nat.add_assoc, Nat.add_assoc, Nat.add_assoc]; congr 1
         (conv => rhs; rw [Nat.add_left_comm]); congr 1
-        rw [← Array.getElem_eq_data_get]
+        rw [List.get_eq_getElem, ← Array.getElem_eq_data_getElem]
         have := @reinsertAux_size α β _; simp [Buckets.size] at this
         induction source[i].toList generalizing target <;> simp [*, Nat.succ_add]; rfl
     · next H =>
@@ -113,8 +112,8 @@ where
       rw [← (_ : source.data.map (fun _ => .nil) = source.data)]
       · simp only [List.map_map]
         induction source.data <;> simp [*]
-      refine List.ext_get (by simp) fun j h₁ h₂ => ?_
-      simp only [List.get_map, Array.data_length]
+      refine List.ext_getElem (by simp) fun j h₁ h₂ => ?_
+      simp only [List.getElem_map, Array.data_length]
       have := (hs j (Nat.lt_of_lt_of_le h₂ (Nat.not_lt.1 H))).symm
       rwa [List.getElem?_eq_getElem] at this
   termination_by source.size - i

--- a/Batteries/Data/HashMap/WF.lean
+++ b/Batteries/Data/HashMap/WF.lean
@@ -105,7 +105,7 @@ where
           List.length_nil, Nat.sum_append, Nat.sum_cons, Nat.zero_add, Array.data_length]
         rw [Nat.add_assoc, Nat.add_assoc, Nat.add_assoc]; congr 1
         (conv => rhs; rw [Nat.add_left_comm]); congr 1
-        rw [List.get_eq_getElem, ← Array.getElem_eq_data_getElem]
+        rw [← Array.getElem_eq_data_getElem]
         have := @reinsertAux_size α β _; simp [Buckets.size] at this
         induction source[i].toList generalizing target <;> simp [*, Nat.succ_add]; rfl
     · next H =>

--- a/Batteries/Data/List/EraseIdx.lean
+++ b/Batteries/Data/List/EraseIdx.lean
@@ -73,6 +73,7 @@ theorem mem_eraseIdx_iff_getElem {x : α} :
   | a::l, k+1 => by
     simp [Fin.exists_fin_succ, mem_eraseIdx_iff_getElem, @eq_comm _ a, k.succ_ne_zero.symm]
 
+@[deprecated mem_eraseIdx_iff_getElem (since := "2024-06-12")]
 theorem mem_eraseIdx_iff_get {x : α} {l} {k} :
     x ∈ eraseIdx l k ↔ ∃ i : Fin l.length, ↑i ≠ k ∧ l.get i = x := by
   simp [mem_eraseIdx_iff_getElem]
@@ -86,6 +87,7 @@ theorem mem_eraseIdx_iff_getElem? {x : α} {l} {k} : x ∈ eraseIdx l k ↔ ∃ 
     obtain ⟨h', -⟩ := getElem?_eq_some.1 h
     exact ⟨h', h⟩
 
+@[deprecated mem_eraseIdx_iff_getElem? (since := "2024-06-12")]
 theorem mem_eraseIdx_iff_get? {x : α} {l} {k} : x ∈ eraseIdx l k ↔ ∃ i ≠ k, l.get? i = x := by
   simp [mem_eraseIdx_iff_getElem?]
 

--- a/Batteries/Data/List/EraseIdx.lean
+++ b/Batteries/Data/List/EraseIdx.lean
@@ -63,20 +63,30 @@ protected theorem IsPrefix.eraseIdx {l l' : List α} (h : l <+: l') (k : Nat) :
     rw [Nat.not_lt] at hkl
     simp [eraseIdx_append_of_length_le hkl, eraseIdx_of_length_le hkl]
 
-theorem mem_eraseIdx_iff_get {x : α} :
-    ∀ {l} {k}, x ∈ eraseIdx l k ↔ ∃ i : Fin l.length, ↑i ≠ k ∧ l.get i = x
+theorem mem_eraseIdx_iff_getElem {x : α} :
+    ∀ {l} {k}, x ∈ eraseIdx l k ↔ ∃ i : Fin l.length, ↑i ≠ k ∧ l[i.1] = x
   | [], _ => by
     simp only [eraseIdx, Fin.exists_iff, not_mem_nil, false_iff]
     rintro ⟨i, h, -⟩
     exact Nat.not_lt_zero _ h
   | a::l, 0 => by simp [Fin.exists_fin_succ, mem_iff_get]
   | a::l, k+1 => by
-    simp [Fin.exists_fin_succ, mem_eraseIdx_iff_get, @eq_comm _ a, k.succ_ne_zero.symm]
+    simp [Fin.exists_fin_succ, mem_eraseIdx_iff_getElem, @eq_comm _ a, k.succ_ne_zero.symm]
+
+theorem mem_eraseIdx_iff_get {x : α} {l} {k} :
+    x ∈ eraseIdx l k ↔ ∃ i : Fin l.length, ↑i ≠ k ∧ l.get i = x := by
+  simp [mem_eraseIdx_iff_getElem]
+
+theorem mem_eraseIdx_iff_getElem? {x : α} {l} {k} : x ∈ eraseIdx l k ↔ ∃ i ≠ k, l[i]? = some x := by
+  simp only [mem_eraseIdx_iff_getElem, getElem_eq_iff, Fin.exists_iff, exists_and_left]
+  refine exists_congr fun i => and_congr_right' ?_
+  constructor
+  · rintro ⟨_, h⟩; exact h
+  · rintro h;
+    obtain ⟨h', -⟩ := getElem?_eq_some.1 h
+    exact ⟨h', h⟩
 
 theorem mem_eraseIdx_iff_get? {x : α} {l} {k} : x ∈ eraseIdx l k ↔ ∃ i ≠ k, l.get? i = x := by
-  simp only [mem_eraseIdx_iff_get, Fin.exists_iff, exists_and_left, get_eq_iff, exists_prop]
-  refine exists_congr fun i => and_congr_right' <| and_iff_right_of_imp fun h => ?_
-  obtain ⟨h, -⟩ := get?_eq_some.1 h
-  exact h
+  simp [mem_eraseIdx_iff_getElem?]
 
 end List

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -397,6 +397,7 @@ theorem exists_of_set {l : List α} (h : n < l.length) :
     ∃ l₁ a l₂, l = l₁ ++ a :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ := by
   rw [set_eq_modifyNth]; exact exists_of_modifyNth _ h
 
+set_option linter.deprecated false in
 theorem exists_of_set' {l : List α} (h : n < l.length) :
     ∃ l₁ l₂, l = l₁ ++ l.get ⟨n, h⟩ :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ :=
   have ⟨_, _, _, h₁, h₂, h₃⟩ := exists_of_set h; ⟨_, _, get_of_append h₁ h₂ ▸ h₁, h₂, h₃⟩

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -247,18 +247,21 @@ theorem getElem_eq_iff {l : List α} {n : Nat} {h : n < l.length} : l[n] = x ↔
   simp only [get_eq_getElem, get?_eq_getElem?, getElem?_eq_some]
   exact ⟨fun w => ⟨h, w⟩, fun h => h.2⟩
 
+@[deprecated getElem_eq_iff (since := "2024-06-12")]
 theorem get_eq_iff : List.get l n = x ↔ l.get? n.1 = some x := by
   simp [getElem_eq_iff]
 
-theorem get?_inj
-    (h₀ : i < xs.length) (h₁ : Nodup xs) (h₂ : xs.get? i = xs.get? j) : i = j := by
+theorem getElem?_inj
+    (h₀ : i < xs.length) (h₁ : Nodup xs) (h₂ : xs[i]? = xs[j]?) : i = j := by
   induction xs generalizing i j with
   | nil => cases h₀
   | cons x xs ih =>
     match i, j with
     | 0, 0 => rfl
     | i+1, j+1 => simp; cases h₁ with
-      | cons ha h₁ => exact ih (Nat.lt_of_succ_lt_succ h₀) h₁ h₂
+      | cons ha h₁ =>
+        simp only [getElem?_cons_succ] at h₂
+        exact ih (Nat.lt_of_succ_lt_succ h₀) h₁ h₂
     | i+1, 0 => ?_
     | 0, j+1 => ?_
     all_goals
@@ -268,6 +271,12 @@ theorem get?_inj
       rw [mem_iff_get?]
       simp only [get?_eq_getElem?]
     exact ⟨_, h₂⟩; exact ⟨_ , h₂.symm⟩
+
+@[deprecated getElem?_inj (since := "2024-06-12")]
+theorem get?_inj
+    (h₀ : i < xs.length) (h₁ : Nodup xs) (h₂ : xs.get? i = xs.get? j) : i = j := by
+  apply getElem?_inj h₀ h₁
+  simp_all
 
 /-! ### drop -/
 
@@ -312,6 +321,7 @@ theorem getElem?_modifyNth (f : α → α) :
     cases h' : l[m]? <;> by_cases h : n = m <;>
       simp [h, if_pos, if_neg, Option.map, mt Nat.succ.inj, not_false_iff, h']
 
+@[deprecated getElem?_modifyNth (since := "2024-06-12")]
 theorem get?_modifyNth (f : α → α) (n) (l : List α) (m) :
     (modifyNth f n l).get? m = (fun a => if n = m then f a else a) <$> l.get? m := by
   simp [getElem?_modifyNth]
@@ -336,17 +346,19 @@ theorem exists_of_modifyNthTail (f : List α → List α) {n} {l : List α} (h :
   modifyNthTail_length _ fun l => by cases l <;> rfl
 
 @[simp] theorem getElem?_modifyNth_eq (f : α → α) (n) (l : List α) :
-  (modifyNth f n l)[n]? = f <$> l[n]? := by
+    (modifyNth f n l)[n]? = f <$> l[n]? := by
   simp only [getElem?_modifyNth, if_pos]
 
+@[deprecated getElem?_modifyNth_eq (since := "2024-06-12")]
 theorem get?_modifyNth_eq (f : α → α) (n) (l : List α) :
-  (modifyNth f n l).get? n = f <$> l.get? n := by
-  simp only [get?_modifyNth, if_pos]
+    (modifyNth f n l).get? n = f <$> l.get? n := by
+  simp [getElem?_modifyNth_eq]
 
 @[simp] theorem getElem?_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
     (modifyNth f m l)[n]? = l[n]? := by
   simp only [getElem?_modifyNth, if_neg h, id_map']
 
+@[deprecated getElem?_modifyNth_ne (since := "2024-06-12")]
 theorem get?_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
     (modifyNth f m l).get? n = l.get? n := by
   simp [h]
@@ -406,19 +418,23 @@ theorem exists_of_set' {l : List α} (h : n < l.length) :
 theorem getElem?_set_eq (a : α) (n) (l : List α) : (set l n a)[n]? = (fun _ => a) <$> l[n]? := by
   simp only [set_eq_modifyNth, getElem?_modifyNth_eq]
 
+@[deprecated getElem?_set_eq (since := "2024-06-12")]
 theorem get?_set_eq (a : α) (n) (l : List α) : (set l n a).get? n = (fun _ => a) <$> l.get? n := by
   simp
 
 theorem getElem?_set_eq_of_lt (a : α) {n} {l : List α} (h : n < length l) :
-  (set l n a)[n]? = some a := by rw [getElem?_set_eq, getElem?_eq_getElem h]; rfl
+    (set l n a)[n]? = some a := by rw [getElem?_set_eq, getElem?_eq_getElem h]; rfl
 
+@[deprecated getElem?_set_eq_of_lt (since := "2024-06-12")]
 theorem get?_set_eq_of_lt (a : α) {n} {l : List α} (h : n < length l) :
-  (set l n a).get? n = some a := by rw [get?_set_eq, get?_eq_get h]; rfl
+    (set l n a).get? n = some a := by
+  rw [get?_eq_getElem?,getElem?_set_eq, getElem?_eq_getElem h]; rfl
 
 @[simp]
 theorem getElem?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a)[n]? = l[n]? := by
   simp only [set_eq_modifyNth, getElem?_modifyNth_ne _ _ h]
 
+@[deprecated getElem?_set_ne (since := "2024-06-12")]
 theorem get?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get? n = l.get? n := by
   simp [h]
 
@@ -426,6 +442,7 @@ theorem getElem?_set (a : α) {m n} (l : List α) :
     (set l m a)[n]? = if m = n then (fun _ => a) <$> l[n]? else l[n]? := by
   by_cases m = n <;> simp [*]
 
+@[deprecated getElem?_set (since := "2024-06-12")]
 theorem get?_set (a : α) {m n} (l : List α) :
     (set l m a).get? n = if m = n then (fun _ => a) <$> l.get? n else l.get? n := by
   simp [getElem?_set]
@@ -440,14 +457,14 @@ theorem get?_set_of_lt' (a : α) {m n} (l : List α) (h : m < length l) :
 
 theorem drop_set_of_lt (a : α) {n m : Nat} (l : List α) (h : n < m) :
     (l.set n a).drop m = l.drop m :=
-  List.ext_get? fun i => by rw [get?_drop, get?_drop, get?_set_ne _ _ (by omega)]
+  List.ext_getElem? fun i => by rw [getElem?_drop, getElem?_drop, getElem?_set_ne _ _ (by omega)]
 
 theorem take_set_of_lt (a : α) {n m : Nat} (l : List α) (h : m < n) :
     (l.set n a).take m = l.take m :=
-  List.ext_get? fun i => by
-    rw [get?_take_eq_if, get?_take_eq_if]
+  List.ext_getElem? fun i => by
+    rw [getElem?_take_eq_if, getElem?_take_eq_if]
     split
-    · next h' => rw [get?_set_ne _ _ (by omega)]
+    · next h' => rw [getElem?_set_ne _ _ (by omega)]
     · rfl
 
 /-! ### removeNth -/
@@ -1376,14 +1393,16 @@ theorem getElem?_range' (s step) :
     exact (getElem?_range' (s + step) step (Nat.lt_of_add_lt_add_right h)).trans <| by
       simp [Nat.mul_succ, Nat.add_assoc, Nat.add_comm]
 
+@[deprecated getElem?_range' (since := "2024-06-12")]
 theorem get?_range' (s step) {m n : Nat} (h : m < n) :
     get? (range' s n step) m = some (s + step * m) := by
   simp [getElem?_range', h]
 
 @[simp] theorem getElem_range' {n m step} (i) (H : i < (range' n m step).length) :
     (range' n m step)[i] = n + step * i :=
-  (get?_eq_some.1 <| get?_range' n step (by simpa using H)).2
+  (getElem?_eq_some.1 <| getElem?_range' n step (by simpa using H)).2
 
+@[deprecated getElem_range' (since := "2024-06-12")]
 theorem get_range' {n m step} (i) (H : i < (range' n m step).length) :
     get (range' n m step) ⟨i, H⟩ = n + step * i := by
   simp
@@ -1433,6 +1452,7 @@ theorem self_mem_range_succ (n : Nat) : n ∈ range (n + 1) := by simp
 theorem getElem?_range {m n : Nat} (h : m < n) : (range n)[m]? = some m := by
   simp [range_eq_range', getElem?_range' _ _ h]
 
+@[deprecated getElem?_range (since := "2024-06-12")]
 theorem get?_range {m n : Nat} (h : m < n) : get? (range n) m = some m := by
   simp [getElem?_range, h]
 
@@ -1465,6 +1485,7 @@ theorem reverse_range' : ∀ s n : Nat, reverse (range' s n) = map (s + n - 1 - 
 @[simp] theorem getElem_range {n} (i) (H : i < (range n).length) : (range n)[i] = i :=
   Option.some.inj <| by rw [← getElem?_eq_getElem _, getElem?_range (by simpa using H)]
 
+@[deprecated getElem_range (since := "2024-06-12")]
 theorem get_range {n} (i) (H : i < (range n).length) : get (range n) ⟨i, H⟩ = i := by
   simp
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -409,10 +409,9 @@ theorem exists_of_set {l : List α} (h : n < l.length) :
     ∃ l₁ a l₂, l = l₁ ++ a :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ := by
   rw [set_eq_modifyNth]; exact exists_of_modifyNth _ h
 
-set_option linter.deprecated false in
 theorem exists_of_set' {l : List α} (h : n < l.length) :
-    ∃ l₁ l₂, l = l₁ ++ l.get ⟨n, h⟩ :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ :=
-  have ⟨_, _, _, h₁, h₂, h₃⟩ := exists_of_set h; ⟨_, _, get_of_append h₁ h₂ ▸ h₁, h₂, h₃⟩
+    ∃ l₁ l₂, l = l₁ ++ l[n] :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ :=
+  have ⟨_, _, _, h₁, h₂, h₃⟩ := exists_of_set h; ⟨_, _, getElem_of_append h₁ h₂ ▸ h₁, h₂, h₃⟩
 
 @[simp]
 theorem getElem?_set_eq (a : α) (n) (l : List α) : (set l n a)[n]? = (fun _ => a) <$> l[n]? := by

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -243,9 +243,12 @@ theorem tail_eq_tail? (l) : @tail α l = (tail? l).getD [] := by simp [tail_eq_t
 
 /-! ### get? -/
 
-theorem get_eq_iff : List.get l n = x ↔ l.get? n.1 = some x := by
+theorem getElem_eq_iff {l : List α} {n : Nat} {h : n < l.length} : l[n] = x ↔ l[n]? = some x := by
   simp only [get_eq_getElem, get?_eq_getElem?, getElem?_eq_some]
-  exact ⟨fun h => ⟨n.2, h⟩, fun h => h.2⟩
+  exact ⟨fun w => ⟨h, w⟩, fun h => h.2⟩
+
+theorem get_eq_iff : List.get l n = x ↔ l.get? n.1 = some x := by
+  simp [getElem_eq_iff]
 
 theorem get?_inj
     (h₀ : i < xs.length) (h₁ : Nodup xs) (h₂ : xs.get? i = xs.get? j) : i = j := by

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -380,8 +380,8 @@ theorem modifyNth_eq_take_drop (f : α → α) :
   modifyNthTail_eq_take_drop _ rfl
 
 theorem modifyNth_eq_take_cons_drop (f : α → α) {n l} (h) :
-    modifyNth f n l = take n l ++ f (get l ⟨n, h⟩) :: drop (n + 1) l := by
-  rw [modifyNth_eq_take_drop, drop_eq_get_cons h]; rfl
+    modifyNth f n l = take n l ++ f l[n] :: drop (n + 1) l := by
+  rw [modifyNth_eq_take_drop, drop_eq_getElem_cons h]; rfl
 
 /-! ### set -/
 

--- a/Batteries/Data/List/Pairwise.lean
+++ b/Batteries/Data/List/Pairwise.lean
@@ -247,6 +247,7 @@ theorem pairwise_iff_getElem : Pairwise R l ↔
     rcases h' with ⟨rfl, rfl⟩
     apply h; simpa using hij
 
+@[deprecated pairwise_iff_getElem (since := "2024-06-12")]
 theorem pairwise_iff_get : Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
   rw [pairwise_iff_getElem]
   constructor <;> intro h

--- a/Batteries/Data/List/Pairwise.lean
+++ b/Batteries/Data/List/Pairwise.lean
@@ -234,18 +234,26 @@ theorem sublist_eq_map_get (h : l' <+ l) : ∃ is : List (Fin l.length),
     refine ⟨⟨0, by simp [Nat.zero_lt_succ]⟩ :: is.map (·.succ), ?_⟩
     simp [comp_def, pairwise_map, IH, ← get_eq_getElem]
 
-theorem pairwise_iff_get : Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
+theorem pairwise_iff_getElem : Pairwise R l ↔
+    ∀ (i j : Nat) (_hi : i < l.length) (_hj : j < l.length) (_hij : i < j), R l[i] l[j] := by
   rw [pairwise_iff_forall_sublist]
   constructor <;> intro h
-  · intros i j h'
+  · intros i j hi hj h'
     apply h
-    apply map_get_sublist (is := [i, j])
-    rw [Fin.lt_def] at h'; simp [h']
+    simpa [h'] using map_get_sublist (is := [⟨i, hi⟩, ⟨j, hj⟩])
   · intros a b h'
     have ⟨is, h', hij⟩ := sublist_eq_map_get h'
     rcases is with ⟨⟩ | ⟨a', ⟨⟩ | ⟨b', ⟨⟩⟩⟩ <;> simp at h'
     rcases h' with ⟨rfl, rfl⟩
     apply h; simpa using hij
+
+theorem pairwise_iff_get : Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
+  rw [pairwise_iff_getElem]
+  constructor <;> intro h
+  · intros i j h'
+    exact h _ _ _ _ h'
+  · intros i j hi hj h'
+    exact h ⟨i, hi⟩ ⟨j, hj⟩ h'
 
 theorem pairwise_replicate {α : Type _} {r : α → α → Prop} {x : α} (hx : r x x) :
     ∀ n : Nat, Pairwise r (List.replicate n x)

--- a/Batteries/Data/List/Pairwise.lean
+++ b/Batteries/Data/List/Pairwise.lean
@@ -213,7 +213,7 @@ theorem map_get_sublist {l : List α} {is : List (Fin l.length)} (h : is.Pairwis
     simp; cases hl'
     have := IH h.of_cons (hd+1) _ rfl (pairwise_cons.mp h).1
     specialize his hd (.head _)
-    have := (drop_eq_get_cons ..).symm ▸ this.cons₂ (get l hd)
+    have := (drop_eq_getElem_cons ..).symm ▸ this.cons₂ (get l hd)
     have := Sublist.append (nil_sublist (take hd l |>.drop n)) this
     rwa [nil_append, ← (drop_append_of_le_length ?_), take_append_drop] at this
     simp [Nat.min_eq_left (Nat.le_of_lt hd.isLt), his]

--- a/Batteries/Data/List/Pairwise.lean
+++ b/Batteries/Data/List/Pairwise.lean
@@ -247,7 +247,6 @@ theorem pairwise_iff_getElem : Pairwise R l ↔
     rcases h' with ⟨rfl, rfl⟩
     apply h; simpa using hij
 
-@[deprecated pairwise_iff_getElem (since := "2024-06-12")]
 theorem pairwise_iff_get : Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
   rw [pairwise_iff_getElem]
   constructor <;> intro h

--- a/Batteries/Data/List/Pairwise.lean
+++ b/Batteries/Data/List/Pairwise.lean
@@ -232,7 +232,7 @@ theorem sublist_eq_map_get (h : l' <+ l) : ∃ is : List (Fin l.length),
   | cons₂ _ _ IH =>
     rcases IH with ⟨is,IH⟩
     refine ⟨⟨0, by simp [Nat.zero_lt_succ]⟩ :: is.map (·.succ), ?_⟩
-    simp [comp_def, pairwise_map, IH]
+    simp [comp_def, pairwise_map, IH, ← get_eq_getElem]
 
 theorem pairwise_iff_get : Pairwise R l ↔ ∀ (i j) (_hij : i < j), R (get l i) (get l j) := by
   rw [pairwise_iff_forall_sublist]

--- a/Batteries/Tactic/Lint/Frontend.lean
+++ b/Batteries/Tactic/Lint/Frontend.lean
@@ -125,9 +125,11 @@ def printWarning (declName : Name) (warning : MessageData) (useErrorFormat : Boo
   (filePath : System.FilePath := default) : CoreM MessageData := do
   if useErrorFormat then
     if let some range ← findDeclarationRanges? declName then
-      return m!"{filePath}:{range.range.pos.line}:{range.range.pos.column + 1}: error: {
+      let msg ← addMessageContextPartial
+        m!"{filePath}:{range.range.pos.line}:{range.range.pos.column + 1}: error: {
           ← mkConstWithLevelParams declName} {warning}"
-  pure m!"#check {← mkConstWithLevelParams declName} /- {warning} -/"
+      return msg
+  addMessageContextPartial m!"#check {← mkConstWithLevelParams declName} /- {warning} -/"
 
 /-- Formats a map of linter warnings using `print_warning`, sorted by line number. -/
 def printWarnings (results : HashMap Name MessageData) (filePath : System.FilePath := default)

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-06-07
+leanprover/lean4-pr-releases:pr-release-4400

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-06-06
+leanprover/lean4:nightly-2024-06-07

--- a/test/congr.lean
+++ b/test/congr.lean
@@ -38,7 +38,7 @@ section
 -- Adaptation note: the next two examples have always failed if `List.ext` was in scope,
 -- but until nightly-2024-04-24 (when `List.ext` was upstreamed), it wasn't in scope.
 -- In order to preserve the test behaviour we locally remove the `ext` attribute.
-attribute [-ext] List.ext
+attribute [-ext] List.ext_getElem?
 
 private opaque List.sum : List Nat → Nat
 


### PR DESCRIPTION
This shouldn't be merged until leanprover/lean4#4400 lands in a nightly.