### PR TITLE
chore: remove 'meta if' from lakefile

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -18,9 +18,6 @@ lean_exe runLinter where
   srcDir := "scripts"
   supportInterpreter := true
 
-meta if get_config? doc |>.isSome then
-require «doc-gen4» from git "https://github.com/leanprover/doc-gen4" @ "main"
-
 @[test_driver]
 lean_exe test where
   srcDir := "scripts"


### PR DESCRIPTION
As far as I understand, no human or automation ever runs doc-gen on `Batteries`. Instead documentation is generated as part of Mathlib's documentation.

If that is the case, I would like to remove the `doc-gen` dependency from the `lakefile`.

(This is on the path to moving to a `lakefile.toml`, and eventually possibly deprecating `meta if` in `lakefile.lean`.)