### PR TITLE
chore: remove `proof_wanted` in HashMap.Lemmas

### DIFF
--- a/Batteries/Data/HashMap/Lemmas.lean
+++ b/Batteries/Data/HashMap/Lemmas.lean
@@ -7,6 +7,13 @@ import Batteries.Data.HashMap.Basic
 import Batteries.Data.Array.Lemmas
 import Batteries.Util.ProofWanted
 
+/-!
+# Lemmas for `Batteries.HashMap`
+
+Note that Lean core provides an alternative hash map implementation, `Std.HashMap`, which comes with
+more lemmas. See the module `Std.Data.HashMap.Lemmas`.
+-/
+
 namespace Batteries.HashMap
 
 namespace Imp
@@ -20,6 +27,3 @@ end Imp
 
 @[simp] theorem empty_find? [BEq α] [Hashable α] {a : α} :
     (∅ : HashMap α β).find? a = none := by simp [find?, Imp.find?]
-
-proof_wanted insert_find? [BEq α] [Hashable α] (m : HashMap α β) (a a' : α) (b : β) :
-    (m.insert a b).find? a' = if a' == a then some b else m.find? a'

--- a/Batteries/Data/HashMap/Lemmas.lean
+++ b/Batteries/Data/HashMap/Lemmas.lean
@@ -5,7 +5,6 @@ Authors: Scott Morrison
 -/
 import Batteries.Data.HashMap.Basic
 import Batteries.Data.Array.Lemmas
-import Batteries.Util.ProofWanted
 
 /-!
 # Lemmas for `Batteries.HashMap`

--- a/Batteries/Data/HashMap/Lemmas.lean
+++ b/Batteries/Data/HashMap/Lemmas.lean
@@ -26,3 +26,8 @@ end Imp
 
 @[simp] theorem empty_find? [BEq α] [Hashable α] {a : α} :
     (∅ : HashMap α β).find? a = none := by simp [find?, Imp.find?]
+
+-- `Std.HashMap` has this lemma (as `getElem?_insert`) and many more, so working on this
+-- `proof_wanted` is likely not a good use of your time.
+-- proof_wanted insert_find? [BEq α] [Hashable α] (m : HashMap α β) (a a' : α) (b : β) :
+--     (m.insert a b).find? a' = if a' == a then some b else m.find? a'


### PR DESCRIPTION
It would probably not be a good use of anyone's time to work on that sorry right now, and there was [some confusion on Zulip](https://leanprover.zulipchat.com/#narrow/stream/224796-Geographic-locality/topic/New.20York.20City.2C.20USA/near/449684763) today, so I suggest removing the `proof_wanted`.