### PR TITLE
doc: fix outdated docstring

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -239,9 +239,7 @@ def findUnusedHaves (e : Expr) : MetaM (Array MessageData) := do
     | _ => return
   res.get
 
-/-- A linter for checking that declarations don't have unused term mode have statements. We do not
-tag this as `@[env_linter]` so that it is not in the default linter set as it is slow and an
-uncommon problem. -/
+/-- A linter for checking that declarations don't have unused term mode have statements. -/
 @[env_linter] def unusedHavesSuffices : Linter where
   noErrorsFound := "No declarations have unused term mode have statements."
   errorsFound := "THE FOLLOWING DECLARATIONS HAVE INEFFECTUAL TERM MODE HAVE/SUFFICES BLOCKS. \


### PR DESCRIPTION
The `unusedHavesSuffices` linter is run by default now: remove the part of its docstring which says otherwise.