### PR TITLE
feat: allow configuring additional linters to run

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -57,7 +57,7 @@ unsafe def main (args : List String) : IO Unit := do
     let state := { env }
     Prod.fst <$> (CoreM.toIO · ctx state) do
       let decls ← getDeclsInPackage module.getRoot
-      let linters ← getChecks (slow := true) (useAlso := none)
+      let linters ← getChecks (slow := true) (runAlways := none) (runOnly := none)
       let results ← lintCore decls linters
       if update then
         writeJsonFile (α := NoLints) nolintsFile <|

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -57,7 +57,7 @@ unsafe def main (args : List String) : IO Unit := do
     let state := { env }
     Prod.fst <$> (CoreM.toIO · ctx state) do
       let decls ← getDeclsInPackage module.getRoot
-      let linters ← getChecks (slow := true) (useOnly := false)
+      let linters ← getChecks (slow := true) (useAlso := none)
       let results ← lintCore decls linters
       if update then
         writeJsonFile (α := NoLints) nolintsFile <|


### PR DESCRIPTION
Extend `getChecks` to allow an additional list of linters, which is always run. This can be used downstream to e.g. enable the `docBlameThm` or `explicitVarsOfIff` linters without modifying batteries.

As part of this, we
- update fix the function docstring (which was quite outdated anyway)
- remove the `useOnly` option: the equivalent effect can be achieved by filtering the list of linters afterwards; *adding* linters cannot, hence must be performed in this function. (That said, I'm happy to add this functionality back if desired.)
- rename a variable `dflt` to the more readable `default`
- adjust the logic of the #lint command accordingly
Note that `test/lint_simpNF.lean` lies on this (the docBlame linter warns there) - so this changed is already tested.