### PR TITLE
chore: fix more Std -> Batteries

### DIFF
--- a/Batteries/CodeAction/Attr.lean
+++ b/Batteries/CodeAction/Attr.lean
@@ -14,7 +14,7 @@ import Lean.Server.CodeActions
 * Attribute `@[tactic_code_action]` collects code actions which will be called
   on each occurrence of a tactic.
 -/
-namespace Std.CodeAction
+namespace Batteries.CodeAction
 
 open Lean Elab Server Lsp RequestM Snapshots
 

--- a/Batteries/CodeAction/Basic.lean
+++ b/Batteries/CodeAction/Basic.lean
@@ -18,7 +18,7 @@ on each occurrence of a hole (`_`, `?_` or `sorry`).
 attempt to use this code action provider when browsing the `Batteries.CodeAction.Hole.Attr` file
 itself.)
 -/
-namespace Std.CodeAction
+namespace Batteries.CodeAction
 
 open Lean Elab Term Server RequestM
 

--- a/Batteries/CodeAction/Deprecated.lean
+++ b/Batteries/CodeAction/Deprecated.lean
@@ -15,8 +15,8 @@ This is an opt-in mechanism for making machine-applicable `@[deprecated]` defini
 whenever the deprecation lint also fires, allowing the user to replace the usage of the deprecated
 constant.
 -/
-namespace Std
-open Lean Elab Server Lsp RequestM
+namespace Batteries
+open Lean Elab Server Lsp RequestM CodeAction
 
 /-- An environment extension for identifying `@[deprecated]` definitions which can be auto-fixed -/
 initialize machineApplicableDeprecated : TagDeclarationExtension ← mkTagDeclarationExtension

--- a/Batteries/CodeAction/Misc.lean
+++ b/Batteries/CodeAction/Misc.lean
@@ -15,7 +15,7 @@ import Lean.Server.CodeActions.Provider
 
 This declares some basic tactic code actions, using the `@[tactic_code_action]` API.
 -/
-namespace Std.CodeAction
+namespace Batteries.CodeAction
 
 open Lean Meta Elab Server RequestM CodeAction
 

--- a/Batteries/Tactic/Alias.lean
+++ b/Batteries/Tactic/Alias.lean
@@ -19,7 +19,7 @@ an iff theorem.
 
 namespace Batteries.Tactic.Alias
 
-open Lean Elab Parser.Command Std
+open Lean Elab Parser.Command
 
 /-- An alias can be in one of three forms -/
 inductive AliasInfo where

--- a/Batteries/Tactic/Lint/Basic.lean
+++ b/Batteries/Tactic/Lint/Basic.lean
@@ -9,7 +9,7 @@ import Lean.Elab.Exception
 
 open Lean Meta
 
-namespace Std.Tactic.Lint
+namespace Batteries.Tactic.Lint
 
 /-!
 # Basic linter types and attributes

--- a/Batteries/Tactic/Lint/Frontend.lean
+++ b/Batteries/Tactic/Lint/Frontend.lean
@@ -52,8 +52,8 @@ omits it from only the specified linter checks.
 sanity check, lint, cleanup, command, tactic
 -/
 
-namespace Std.Tactic.Lint
-open Lean Std
+namespace Batteries.Tactic.Lint
+open Lean
 
 /-- Verbosity for the linter output. -/
 inductive LintVerbosity

--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -14,7 +14,7 @@ import Batteries.Tactic.Lint.Basic
 
 open Lean Meta
 
-namespace Std.Tactic.Lint
+namespace Batteries.Tactic.Lint
 
 /-!
 # Various linters

--- a/Batteries/Tactic/Lint/Simp.lean
+++ b/Batteries/Tactic/Lint/Simp.lean
@@ -9,7 +9,7 @@ import Batteries.Tactic.OpenPrivate
 import Batteries.Util.LibraryNote
 open Lean Meta
 
-namespace Std.Tactic.Lint
+namespace Batteries.Tactic.Lint
 
 /-!
 # Linter for simplification lemmas
@@ -85,8 +85,6 @@ where
   trieElements (arr)
   | Trie.node vs children =>
     children.foldl (init := arr ++ vs) fun arr (_, child) => trieElements arr child
-
-open Std
 
 /-- Add message `msg` to any errors thrown inside `k`. -/
 def decorateError (msg : MessageData) (k : MetaM α) : MetaM α := do

--- a/Batteries/Tactic/Lint/TypeClass.lean
+++ b/Batteries/Tactic/Lint/TypeClass.lean
@@ -6,7 +6,7 @@ Authors: Gabriel Ebner
 import Lean.Meta.Instances
 import Batteries.Tactic.Lint.Basic
 
-namespace Std.Tactic.Lint
+namespace Batteries.Tactic.Lint
 open Lean Meta
 
 /--

--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -2,7 +2,7 @@ import Batteries.Tactic.Lint
 import Batteries.Data.Array.Basic
 import Batteries.Lean.Util.Path
 
-open Lean Core Elab Command Std.Tactic.Lint
+open Lean Core Elab Command Batteries.Tactic.Lint
 open System (FilePath)
 
 /-- The list of `nolints` pulled from the `nolints.json` file -/

--- a/test/lintTC.lean
+++ b/test/lintTC.lean
@@ -1,7 +1,7 @@
 import Batteries.Tactic.Lint.TypeClass
 import Lean.Elab.Command
 
-open Std.Tactic.Lint
+open Batteries.Tactic.Lint
 
 namespace A
 

--- a/test/lintsimp.lean
+++ b/test/lintsimp.lean
@@ -1,6 +1,6 @@
 import Batteries.Tactic.Lint
 
-open Std.Tactic.Lint
+open Batteries.Tactic.Lint
 set_option linter.missingDocs false
 
 def f : Nat := 0


### PR DESCRIPTION
It was still present in the namespaces `Std.Tactic.Lint` and `Std.CodeAction`.