### PR TITLE
feat: some array lemma aliases

### DIFF
--- a/Batteries/Data/Array/Lemmas.lean
+++ b/Batteries/Data/Array/Lemmas.lean
@@ -133,3 +133,15 @@ theorem mapM_empty [Monad m] (f : α → m β) : mapM f #[] = pure #[] := by
   rw [mapM, mapM.map]; rfl
 
 @[simp] theorem map_empty (f : α → β) : map f #[] = #[] := mapM_empty ..
+
+/-! ### mem -/
+
+alias not_mem_empty := not_mem_nil
+
+theorem mem_singleton : a ∈ #[b] ↔ a = b := by simp
+
+/-! ### append -/
+
+alias append_empty := append_nil
+
+alias empty_append := nil_append


### PR DESCRIPTION
Core uses `nil` instead of `empty` for some array lemmas and I keep getting caught by that, so I'm proposing to add aliases for the `empty` variants. I'm also proposing to add `mem_singleton` since that one comes up often enough that I'd like to avoid going through list every time.