### PR TITLE
feat: add finRange

### DIFF
--- a/Batteries/Data/Array/Basic.lean
+++ b/Batteries/Data/Array/Basic.lean
@@ -197,8 +197,10 @@ greater than i.
 def eraseIdxN (a : Array α) (i : Nat) (h : i < a.size := by get_elem_tactic) : Array α :=
   a.feraseIdx ⟨i, h⟩
 
-end Array
+/-- `finRange n` is the array of all elements of `Fin n` in order -/
+def finRange (n) : Array (Fin n) := ofFn id
 
+end Array
 
 namespace Subarray
 

--- a/Batteries/Data/Array/Lemmas.lean
+++ b/Batteries/Data/Array/Lemmas.lean
@@ -159,5 +159,5 @@ alias empty_append := nil_append
 
 @[simp] theorem data_finRange (n) : (finRange n).data = List.finRange n := data_ofFn ..
 
-theorem getElem_finRange (n i) (hi : i < (finRange n).size) :
+theorem getElem_finRange (hi : i < (finRange n).size) :
     (finRange n)[i] = ⟨i, size_finRange n ▸ hi⟩ := by simp [getElem_eq_data_getElem]

--- a/Batteries/Data/Array/Lemmas.lean
+++ b/Batteries/Data/Array/Lemmas.lean
@@ -145,3 +145,19 @@ theorem mem_singleton : a ∈ #[b] ↔ a = b := by simp
 alias append_empty := append_nil
 
 alias empty_append := nil_append
+
+/-! ### ofFn -/
+
+@[simp] theorem data_ofFn (f : Fin n → α) : (ofFn f).data = List.ofFn f := by
+  apply List.ext_getElem
+  · rw [data_length, size_ofFn, List.length_ofFn]
+  · intros; rw [← getElem_eq_data_getElem, getElem_ofFn, List.getElem_ofFn]
+
+/-! ### finRange -/
+
+@[simp] theorem size_finRange (n) : (finRange n).size = n := size_ofFn ..
+
+@[simp] theorem data_finRange (n) : (finRange n).data = List.finRange n := data_ofFn ..
+
+theorem getElem_finRange (n i) (hi : i < (finRange n).size) :
+    (finRange n)[i] = ⟨i, size_finRange n ▸ hi⟩ := by simp [getElem_eq_data_getElem]

--- a/Batteries/Data/Fin/Basic.lean
+++ b/Batteries/Data/Fin/Basic.lean
@@ -3,6 +3,9 @@ Copyright (c) 2017 Robert Y. Lewis. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Robert Y. Lewis, Keeley Hoek, Mario Carneiro
 -/
+import Batteries.Data.Array.Basic
+import Batteries.Data.List.Basic
+import Batteries.Tactic.Alias
 
 namespace Fin
 
@@ -10,7 +13,7 @@ namespace Fin
 def clamp (n m : Nat) : Fin (m + 1) := ⟨min n m, Nat.lt_succ_of_le (Nat.min_le_right ..)⟩
 
 /-- `enum n` is the array of all elements of `Fin n` in order -/
-def enum (n) : Array (Fin n) := Array.ofFn id
+@[deprecated (since:="2024-07-30")] alias enum := Array.finRange
 
 /-- `list n` is the list of all elements of `Fin n` in order -/
-def list (n) : List (Fin n) := (enum n).data
+@[deprecated (since:="2024-07-30")] alias list := List.finRange

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -54,7 +54,8 @@ theorem foldl_eq_foldl_finRange (f : α → Fin n → α) (x) :
     foldl n f x = (List.finRange n).foldl f x := by
   induction n generalizing x with
   | zero => rw [foldl_zero, List.finRange_zero, List.foldl_nil]
-  | succ n ih => rw [foldl_succ, ih, List.finRange_succ, List.foldl_cons, List.foldl_map]
+  | succ n ih =>
+    rw [foldl_succ, ih, List.finRange_succ_eq_zero_cons_map, List.foldl_cons, List.foldl_map]
 
 /-! ### foldr -/
 
@@ -90,7 +91,8 @@ theorem foldr_eq_foldr_finRange (f : Fin n → α → α) (x) :
     foldr n f x = (List.finRange n).foldr f x := by
   induction n with
   | zero => rw [foldr_zero, List.finRange_zero, List.foldr_nil]
-  | succ n ih => rw [foldr_succ, ih, List.finRange_succ, List.foldr_cons, List.foldr_map]
+  | succ n ih =>
+    rw [foldr_succ, ih, List.finRange_succ_eq_zero_cons_map, List.foldr_cons, List.foldr_map]
 
 /-! ### foldl/foldr -/
 

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Batteries.Data.Fin.Basic
+import Batteries.Data.List.Lemmas
 
 namespace Fin
 
@@ -18,46 +19,6 @@ protected theorem le_antisymm {x y : Fin n} (h1 : x ≤ y) (h2 : y ≤ x) : x = 
 /-! ### clamp -/
 
 @[simp] theorem coe_clamp (n m : Nat) : (clamp n m : Nat) = min n m := rfl
-
-/-! ### enum/list -/
-
-@[simp] theorem size_enum (n) : (enum n).size = n := Array.size_ofFn ..
-
-@[simp] theorem enum_zero : (enum 0) = #[] := by simp [enum, Array.ofFn, Array.ofFn.go]
-
-@[simp] theorem getElem_enum (i) (h : i < (enum n).size) : (enum n)[i] = ⟨i, size_enum n ▸ h⟩ :=
-  Array.getElem_ofFn ..
-
-@[simp] theorem length_list (n) : (list n).length = n := by simp [list]
-
-@[simp] theorem getElem_list (i : Nat) (h : i < (list n).length) :
-    (list n)[i] = cast (length_list n) ⟨i, h⟩ := by
-  simp only [list]; rw [← Array.getElem_eq_data_getElem, getElem_enum, cast_mk]
-
-@[deprecated getElem_list (since := "2024-06-12")]
-theorem get_list (i : Fin (list n).length) : (list n).get i = i.cast (length_list n) := by
-  simp [getElem_list]
-
-@[simp] theorem list_zero : list 0 = [] := by simp [list]
-
-theorem list_succ (n) : list (n+1) = 0 :: (list n).map Fin.succ := by
-  apply List.ext_get; simp; intro i; cases i <;> simp
-
-theorem list_succ_last (n) : list (n+1) = (list n).map castSucc ++ [last n] := by
-  rw [list_succ]
-  induction n with
-  | zero => rfl
-  | succ n ih =>
-    rw [list_succ, List.map_cons castSucc, ih]
-    simp [Function.comp_def, succ_castSucc]
-
-theorem list_reverse (n) : (list n).reverse = (list n).map rev := by
-  induction n with
-  | zero => rfl
-  | succ n ih =>
-    conv => lhs; rw [list_succ_last]
-    conv => rhs; rw [list_succ]
-    simp [← List.map_reverse, ih, Function.comp_def, rev_succ]
 
 /-! ### foldl -/
 
@@ -89,10 +50,11 @@ theorem foldl_succ_last (f : α → Fin (n+1) → α) (x) :
   | zero => simp [foldl_succ, Fin.last]
   | succ n ih => rw [foldl_succ, ih (f · ·.succ), foldl_succ]; simp [succ_castSucc]
 
-theorem foldl_eq_foldl_list (f : α → Fin n → α) (x) : foldl n f x = (list n).foldl f x := by
+theorem foldl_eq_foldl_finRange (f : α → Fin n → α) (x) :
+    foldl n f x = (List.finRange n).foldl f x := by
   induction n generalizing x with
-  | zero => rw [foldl_zero, list_zero, List.foldl_nil]
-  | succ n ih => rw [foldl_succ, ih, list_succ, List.foldl_cons, List.foldl_map]
+  | zero => rw [foldl_zero, List.finRange_zero, List.foldl_nil]
+  | succ n ih => rw [foldl_succ, ih, List.finRange_succ, List.foldl_cons, List.foldl_map]
 
 /-! ### foldr -/
 
@@ -124,10 +86,11 @@ theorem foldr_succ_last (f : Fin (n+1) → α → α) (x) :
   | zero => simp [foldr_succ, Fin.last]
   | succ n ih => rw [foldr_succ, ih (f ·.succ), foldr_succ]; simp [succ_castSucc]
 
-theorem foldr_eq_foldr_list (f : Fin n → α → α) (x) : foldr n f x = (list n).foldr f x := by
+theorem foldr_eq_foldr_finRange (f : Fin n → α → α) (x) :
+    foldr n f x = (List.finRange n).foldr f x := by
   induction n with
-  | zero => rw [foldr_zero, list_zero, List.foldr_nil]
-  | succ n ih => rw [foldr_succ, ih, list_succ, List.foldr_cons, List.foldr_map]
+  | zero => rw [foldr_zero, List.finRange_zero, List.foldr_nil]
+  | succ n ih => rw [foldr_succ, ih, List.finRange_succ, List.foldr_cons, List.foldr_map]
 
 /-! ### foldl/foldr -/
 

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -59,14 +59,12 @@ theorem foldl_eq_foldl_finRange (f : α → Fin n → α) (x) :
 
 /-! ### foldr -/
 
-unseal foldr.loop in
-theorem foldr_loop_zero (f : Fin n → α → α) (x) : foldr.loop n f ⟨0, Nat.zero_le _⟩ x = x :=
-  rfl
+theorem foldr_loop_zero (f : Fin n → α → α) (x) : foldr.loop n f ⟨0, Nat.zero_le _⟩ x = x := by
+  rw [foldr.loop]
 
-unseal foldr.loop in
 theorem foldr_loop_succ (f : Fin n → α → α) (x) (h : m < n) :
-    foldr.loop n f ⟨m+1, h⟩ x = foldr.loop n f ⟨m, Nat.le_of_lt h⟩ (f ⟨m, h⟩ x) :=
-  rfl
+    foldr.loop n f ⟨m+1, h⟩ x = foldr.loop n f ⟨m, Nat.le_of_lt h⟩ (f ⟨m, h⟩ x) := by
+  rw [foldr.loop]
 
 theorem foldr_loop (f : Fin (n+1) → α → α) (x) (h : m+1 ≤ n+1) :
     foldr.loop (n+1) f ⟨m+1, h⟩ x =

--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -1393,3 +1393,6 @@ where
   | [], r, t => reverseAux t r
   | l, [], t => reverseAux t l
   | a::l, b::r, t => bif s a b then loop l (b::r) (a::t) else loop (a::l) r (b::t)
+
+/-- `finRange n` is the list of all elements of `Fin n` in order -/
+def finRange (n) : List (Fin n) := ofFn id

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -1637,7 +1637,7 @@ theorem getElem_ofFn_go (f : Fin n → α) (i j k h) (hk : k < (ofFn.go f i j h)
 
 @[simp] theorem length_finRange (n) : (finRange n).length = n := length_ofFn ..
 
-@[simp] theorem getElem_finRange (n i) (hi : i < (finRange n).length) :
+@[simp] theorem getElem_finRange (hi : i < (finRange n).length) :
     (finRange n)[i] = ⟨i, length_finRange n ▸ hi⟩ := getElem_ofFn ..
 
 @[simp] theorem finRange_zero : finRange 0 = [] := rfl

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -1642,24 +1642,25 @@ theorem getElem_ofFn_go (f : Fin n → α) (i j k h) (hk : k < (ofFn.go f i j h)
 
 @[simp] theorem finRange_zero : finRange 0 = [] := rfl
 
-theorem finRange_succ (n) : finRange (n+1) = 0 :: (finRange n).map Fin.succ := by
+theorem finRange_succ_eq_zero_cons_map (n) :
+    finRange (n+1) = 0 :: (finRange n).map Fin.succ := by
   apply List.ext_getElem
   · simp
   · intro i _ _; cases i <;> simp
 
-theorem finRange_succ_last (n) :
-    finRange (n+1) = (finRange n).map Fin.castSucc ++ [Fin.last n] := by
-  rw [finRange_succ]
+theorem finRange_succ_eq_map_concat_last (n) :
+    finRange (n+1) = concat ((finRange n).map Fin.castSucc) (Fin.last n) := by
+  rw [finRange_succ_eq_zero_cons_map]
   induction n with
   | zero => rfl
   | succ n ih =>
-    rw [finRange_succ, List.map_cons Fin.castSucc, ih]
+    rw [finRange_succ_eq_zero_cons_map, List.map_cons Fin.castSucc, ih]
     simp [Function.comp_def, Fin.succ_castSucc]
 
 theorem finRange_reverse (n) : (finRange n).reverse = (finRange n).map Fin.rev := by
   induction n with
   | zero => rfl
   | succ n ih =>
-    conv => lhs; rw [finRange_succ_last]
-    conv => rhs; rw [finRange_succ]
+    conv => lhs; rw [finRange_succ_eq_map_concat_last]
+    conv => rhs; rw [finRange_succ_eq_zero_cons_map]
     simp [← List.map_reverse, ih, Function.comp_def, Fin.rev_succ]


### PR DESCRIPTION
This is to correct a name clash from #528 with Mathlib pointed out by @eric-wieser 

We add `List.finRange` and `Array.finRange` (with basic lemmas). The synonyms `Fin.list` and `Fin.enum` are deprecated.