### PR TITLE
feat: add `map` and `mapM` for scalar array types

### DIFF
--- a/Batteries.lean
+++ b/Batteries.lean
@@ -22,6 +22,7 @@ import Batteries.Data.ByteArray
 import Batteries.Data.Char
 import Batteries.Data.DList
 import Batteries.Data.Fin
+import Batteries.Data.FloatArray
 import Batteries.Data.HashMap
 import Batteries.Data.Int
 import Batteries.Data.LazyList

--- a/Batteries/Data/ByteArray.lean
+++ b/Batteries/Data/ByteArray.lean
@@ -12,16 +12,6 @@ namespace ByteArray
 
 theorem getElem_eq_data_getElem (a : ByteArray) (h : i < a.size) : a[i] = a.data[i] := rfl
 
--- TODO: remove once lean4#4801 is applied
-/--
-Low-level version of `size` that directly queries the C array object cached size.
-
-While this is not provable, `usize` always returns the exact size of the array since the
-implementation only supports arrays of size less than `USize.size`.
--/
-@[extern "lean_sarray_size", simp]
-def usize (a : @& ByteArray) : USize := a.size.toUSize
-
 /-! ### uget/uset -/
 
 @[simp] theorem uset_eq_set (a : ByteArray) {i : USize} (h : i.toNat < a.size) (v : UInt8) :

--- a/Batteries/Data/ByteArray.lean
+++ b/Batteries/Data/ByteArray.lean
@@ -12,6 +12,16 @@ namespace ByteArray
 
 theorem getElem_eq_data_getElem (a : ByteArray) (h : i < a.size) : a[i] = a.data[i] := rfl
 
+-- TODO: remove once lean4#4801 is applied
+/--
+Low-level version of `size` that directly queries the C array object cached size.
+
+While this is not provable, `usize` always returns the exact size of the array since the
+implementation only supports arrays of size less than `USize.size`.
+-/
+@[extern "lean_sarray_size", simp]
+def usize (a : @& ByteArray) : USize := a.size.toUSize
+
 /-! ### uget/uset -/
 
 @[simp] theorem uset_eq_set (a : ByteArray) {i : USize} (h : i.toNat < a.size) (v : UInt8) :
@@ -138,3 +148,38 @@ where
       (ofFnAux.go f i acc).data = Array.ofFn.go f i acc.data := by
     rw [ofFnAux.go, Array.ofFn.go]; split; rw [ofFnAux_data f (i+1), push_data]; rfl
   termination_by n - i
+
+/-! ### map/mapM -/
+
+/--
+Unsafe optimized implementation of `mapM`.
+
+This function is unsafe because it relies on the implementation limit that the size of an array is
+always less than `USize.size`.
+-/
+@[inline]
+unsafe def mapMUnsafe [Monad m] (a : ByteArray) (f : UInt8 → m UInt8) : m ByteArray :=
+  loop a 0 a.usize
+where
+  /-- Inner loop for `mapMUnsafe`. -/
+  @[specialize]
+  loop (a : ByteArray) (k s : USize) := do
+    if k < a.usize then
+      let x := a.uget k lcProof
+      let y ← f x
+      let a := a.uset k y lcProof
+      loop a (k+1) s
+    else pure a
+
+/-- `mapM f a` applies the monadic function `f` to each element of the array. -/
+@[implemented_by mapMUnsafe]
+def mapM [Monad m] (a : ByteArray) (f : UInt8 → m UInt8) : m ByteArray := do
+  let mut r := a
+  for i in [0:r.size] do
+    r := r.set! i (← f r[i]!)
+  return r
+
+/-- `map f a` applies the function `f` to each element of the array. -/
+@[inline]
+def map (a : ByteArray) (f : UInt8 → UInt8) : ByteArray :=
+  mapM (m:=Id) a f

--- a/Batteries/Data/FloatArray.lean
+++ b/Batteries/Data/FloatArray.lean
@@ -6,16 +6,6 @@ Authors: François G. Dorais
 
 namespace FloatArray
 
--- TODO: remove once lean4#4801 is applied
-/--
-Low-level version of `size` that directly queries the C array object cached size.
-
-While this is not provable, `usize` always returns the exact size of the array since the
-implementation only supports arrays of size less than `USize.size`.
--/
-@[extern "lean_sarray_size", simp]
-def usize (a : @& FloatArray) : USize := a.size.toUSize
-
 /--
 Unsafe optimized implementation of `mapM`.
 

--- a/Batteries/Data/FloatArray.lean
+++ b/Batteries/Data/FloatArray.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2024 François G. Dorais. All rights reserved.
+Released under Apache 2. license as described in the file LICENSE.
+Authors: François G. Dorais
+-/
+
+namespace FloatArray
+
+-- TODO: remove once lean4#4801 is applied
+/--
+Low-level version of `size` that directly queries the C array object cached size.
+
+While this is not provable, `usize` always returns the exact size of the array since the
+implementation only supports arrays of size less than `USize.size`.
+-/
+@[extern "lean_sarray_size", simp]
+def usize (a : @& FloatArray) : USize := a.size.toUSize
+
+/--
+Unsafe optimized implementation of `mapM`.
+
+This function is unsafe because it relies on the implementation limit that the size of an array is
+always less than `USize.size`.
+-/
+@[inline]
+unsafe def mapMUnsafe [Monad m] (a : FloatArray) (f : Float → m Float) : m FloatArray :=
+  loop a 0 a.usize
+where
+  /-- Inner loop for `mapMUnsafe`. -/
+  @[specialize]
+  loop (a : FloatArray) (k s : USize) := do
+    if k < s then
+      let x := a.uget k lcProof
+      let y ← f x
+      let a := a.uset k y lcProof
+      loop a (k+1) s
+    else pure a
+
+/-- `mapM f a` applies the monadic function `f` to each element of the array. -/
+@[implemented_by mapMUnsafe]
+def mapM [Monad m] (a : FloatArray) (f : Float → m Float) : m FloatArray := do
+  let mut r := a
+  for i in [0:r.size] do
+    r := r.set! i (← f r[i]!)
+  return r
+
+/-- `map f a` applies the function `f` to each element of the array. -/
+@[inline]
+def map (a : FloatArray) (f : Float → Float) : FloatArray :=
+  mapM (m:=Id) a f


### PR DESCRIPTION
These have been recently requested on [Zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Regarding.20map.20and.20extract.20for.20Byte.2FFloatArrays/near/452971124).