### PR TITLE
chore: update .gitpod.yml to pre-build Batteries

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,8 @@ image:
 vscode:
   extensions:
     - leanprover.lean4
+
+tasks:
+  - init: |
+      elan self update
+      lake build


### PR DESCRIPTION
This PR changes the .gitpod.yml file to run `elan self update` and `lake build`. This ensures that contributors don't have to wait for batteries files to build when they open a file

- [x] Test gitpod setup : Open the [branch](https://github.com/Shreyas4991/batteries/tree/gitpod_lake_build) in [gitpod](https://gitpod.io/new/#https://github.com/Shreyas4991/batteries/tree/gitpod_lake_build)