### PR TITLE
chore: adaptations for nightly-2024-09-02

### DIFF
--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -9,12 +9,6 @@ namespace Fin
 
 attribute [norm_cast] val_last
 
-protected theorem le_antisymm_iff {x y : Fin n} : x = y ↔ x ≤ y ∧ y ≤ x :=
-  Fin.ext_iff.trans Nat.le_antisymm_iff
-
-protected theorem le_antisymm {x y : Fin n} (h1 : x ≤ y) (h2 : y ≤ x) : x = y :=
-  Fin.le_antisymm_iff.2 ⟨h1, h2⟩
-
 /-! ### clamp -/
 
 @[simp] theorem coe_clamp (n m : Nat) : (clamp n m : Nat) = min n m := rfl

--- a/Batteries/Data/List/Perm.lean
+++ b/Batteries/Data/List/Perm.lean
@@ -144,7 +144,7 @@ theorem perm_ext_iff_of_nodup {l₁ l₂ : List α} (d₁ : Nodup l₁) (d₂ : 
 theorem Nodup.perm_iff_eq_of_sublist {l₁ l₂ l : List α} (d : Nodup l)
     (s₁ : l₁ <+ l) (s₂ : l₂ <+ l) : l₁ ~ l₂ ↔ l₁ = l₂ := by
   refine ⟨fun h => ?_, fun h => by rw [h]⟩
-  induction s₂ generalizing l₁ with simp [Nodup] at d
+  induction s₂ generalizing l₁ with simp [Nodup, List.forall_mem_ne] at d
   | slnil => exact h.eq_nil
   | cons a s₂ IH =>
     match s₁ with

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2024-08-27
+leanprover/lean4:nightly-2024-09-02


### PR DESCRIPTION
Two lemmas upstreamed, and one lemma in Lean had `@[simp]` removed because it fired too often.