### PR TITLE
chore: upstream/undeprecate String.toAsciiByteArray

### DIFF
--- a/Batteries/Data/String/Basic.lean
+++ b/Batteries/Data/String/Basic.lean
@@ -104,3 +104,16 @@ def stripSuffix (s : String) (suff : Substring) : String :=
 /-- Count the occurrences of a character in a string. -/
 def count (s : String) (c : Char) : Nat :=
   s.foldl (fun n d => if d = c then n + 1 else n) 0
+
+/-- Convert a string of assumed-ASCII characters into a byte array.
+(If any characters are non-ASCII they will be reduced modulo 256.) -/
+def toAsciiByteArray (s : String) : ByteArray :=
+  let rec loop (p : Pos) (out : ByteArray) : ByteArray :=
+    if h : s.atEnd p then out else
+    let c := s.get p
+    have : utf8ByteSize s - (next s p).byteIdx < utf8ByteSize s - p.byteIdx :=
+      Nat.sub_lt_sub_left (Nat.lt_of_not_le <| mt decide_eq_true h)
+        (Nat.lt_add_of_pos_right (Char.utf8Size_pos _))
+    loop (s.next p) (out.push c.toUInt8)
+    termination_by utf8ByteSize s - p.byteIdx
+  loop 0 ByteArray.empty

--- a/Batteries/Data/String/Basic.lean
+++ b/Batteries/Data/String/Basic.lean
@@ -108,7 +108,12 @@ def count (s : String) (c : Char) : Nat :=
 /-- Convert a string of assumed-ASCII characters into a byte array.
 (If any characters are non-ASCII they will be reduced modulo 256.) -/
 def toAsciiByteArray (s : String) : ByteArray :=
-  let rec loop (p : Pos) (out : ByteArray) : ByteArray :=
+  let rec
+  /--
+  Internal implementation of `toAsciiByteArray`.
+  `loop p out = out ++ toAsciiByteArray ({ s with startPos := p } : Substring)`
+  -/
+  loop (p : Pos) (out : ByteArray) : ByteArray :=
     if h : s.atEnd p then out else
     let c := s.get p
     have : utf8ByteSize s - (next s p).byteIdx < utf8ByteSize s - p.byteIdx :=

--- a/Batteries/Data/String/Basic.lean
+++ b/Batteries/Data/String/Basic.lean
@@ -105,8 +105,13 @@ def stripSuffix (s : String) (suff : Substring) : String :=
 def count (s : String) (c : Char) : Nat :=
   s.foldl (fun n d => if d = c then n + 1 else n) 0
 
-/-- Convert a string of assumed-ASCII characters into a byte array.
-(If any characters are non-ASCII they will be reduced modulo 256.) -/
+/--
+Convert a string of assumed-ASCII characters into a byte array.
+(If any characters are non-ASCII they will be reduced modulo 256.)
+
+Note: if you just need the underlying `ByteArray` of a non-ASCII string,
+use `String.toUTF8`.
+-/
 def toAsciiByteArray (s : String) : ByteArray :=
   let rec
   /--


### PR DESCRIPTION
As requested on [zulip](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/deprecated.20String.2EtoAsciiByteArray/near/467132158).

This had been deprecated in Mathlib without a replacement.