### PR TITLE
fix: add trailing line-break in nolints.json

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -15,7 +15,7 @@ def readJsonFile (α) [FromJson α] (path : System.FilePath) : IO α := do
 
 /-- Serialize the given value `a : α` to the file as JSON. -/
 def writeJsonFile [ToJson α] (path : System.FilePath) (a : α) : IO Unit :=
-  IO.FS.writeFile path <| toJson a |>.pretty
+  IO.FS.writeFile path <| toJson a |>.pretty.push '\n'
 
 /--
 Usage: `runLinter [--update] [Batteries.Data.Nat.Basic]`


### PR DESCRIPTION
Reported in [this Zulip thread](https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Configuring.2Fmodernizing.20runLinter/near/472003381).

The fix is similar to what happened already to shake [here](https://github.com/leanprover-community/mathlib4/blob/9890065b5f32e2ab14314294d1b497d229d7c865/Shake/Main.lean#L538).

Ultimately, the reason is that `Lean.Json.pretty` does not add a trailing `\n` to the resulting string.