### PR TITLE
fix: use `by rfl` instead of `rfl` to bypass new compiler bug

### DIFF
--- a/Batteries/Data/Vector/Basic.lean
+++ b/Batteries/Data/Vector/Basic.lean
@@ -34,7 +34,7 @@ syntax "#v[" withoutPosition(sepBy(term, ", ")) "]" : term
 
 open Lean in
 macro_rules
-  | `(#v[ $elems,* ]) => `(Vector.mk (n := $(quote elems.getElems.size)) #[$elems,*] rfl)
+  | `(#v[ $elems,* ]) => `(Vector.mk (n := $(quote elems.getElems.size)) #[$elems,*] (by rfl))
 
 /-- Custom eliminator for `Vector α n` through `Array α` -/
 @[elab_as_elim]


### PR DESCRIPTION
This is a workaround for a bug reported on the [zulip thread](https://leanprover.zulipchat.com/#narrow/stream/348111-batteries/topic/Large.20vector.20hangs/near/473252482)