### PR TITLE
fix: use user's Lean search path in linter

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -37,7 +37,7 @@ unsafe def main (args : List String) : IO Unit := do
         | name => some name
       | _ => none
     | IO.eprintln "Usage: runLinter [--update] [Batteries.Data.Nat.Basic]" *> IO.Process.exit 1
-  searchPathRef.set compile_time_search_path%
+  initSearchPath (← findSysroot)
   let mFile ← findOLean module
   unless (← mFile.pathExists) do
     -- run `lake build module` (and ignore result) if the file hasn't been built yet


### PR DESCRIPTION
Batteries' linter previously encoded the compile-time search path into its executable. This means the linter would break if run from a different environment or machine. It now uses the information from the user's environment to determine the correct search path, making it reasonably portable.