### PR TITLE
chore: move to v4.13.0-rc3

### DIFF
--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.13.0-rc1
+leanprover/lean4:v4.13.0-rc3


### PR DESCRIPTION
Exactly the same as `v4.13.0-rc1`, so this is just for consistency with Mathlib.