### PR TITLE
chore: remove duplicate theorem about lists

### DIFF
--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -17,7 +17,7 @@ namespace List
 
 /-! ### isEmpty -/
 
-theorem isEmpty_iff_eq_nil {l : List α} : l.isEmpty ↔ l = [] := by cases l <;> simp [isEmpty]
+@[deprecated (since := "2024-08-15")] alias isEmpty_iff_eq_nil := isEmpty_iff
 
 /-! ### next? -/
 


### PR DESCRIPTION
The theorem `List.isEmpty_iff_eq_nil` had already been moved to
`Init.Data.List.Lemmas` and renamed `List.isEmpty_iff`.