### PR TITLE
feat: add list function and lemmas

### DIFF
--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -10,6 +10,16 @@ namespace List
 
 /-! ## New definitions -/
 
+/-- Returns the longest common prefix of two lists. -/
+def commonPrefix [DecidableEq α] : (l₁ l₂ : List α) → List α
+  | [], _ => []
+  | _, [] => []
+  | a₁::l₁, a₂::l₂ =>
+    if a₁ = a₂ then
+      a₁ :: (commonPrefix l₁ l₂)
+    else
+      []
+
 /--
 Computes the "bag intersection" of `l₁` and `l₂`, that is,
 the collection of elements of `l₁` which are also in `l₂`. As each element

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -504,6 +504,16 @@ section
 
 variable [DecidableEq α]
 
+theorem commonPrefix_comm (l₁ l₂ : List α) : commonPrefix l₁ l₂ = commonPrefix l₂ l₁ := by
+  cases l₁ <;> cases l₂ <;> simp only [commonPrefix]
+  next a₁ l₁ a₂ l₂ =>
+  split
+  · subst a₁
+    simp only [↓reduceIte, cons.injEq, true_and]
+    apply commonPrefix_comm
+  · next h =>
+    simp [Ne.symm h]
+
 theorem commonPrefix_prefix_left (l₁ l₂ : List α) : commonPrefix l₁ l₂ <+: l₁ := by
   match l₁, l₂ with
   | [],   _  => simp [commonPrefix]

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -546,24 +546,35 @@ theorem commonPrefix_append_append (p l₁ l₂ : List α) :
   | []   => rfl
   | a::p => simpa [commonPrefix] using commonPrefix_append_append p l₁ l₂
 
-theorem not_prefix_and_not_prefix_symm_iff_exists {l₁ l₂ : List α} :
-    ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ ∃ c₁ c₂ pre suf₁ suf₂, c₁ ≠ c₂ ∧ l₁ = pre ++ c₁ :: suf₁ ∧
-      l₂ = pre ++ c₂ :: suf₂ := by
+theorem not_prefix_and_not_prefix_symm_iff {l₁ l₂ p t₁ t₂ : List α} (hp : commonPrefix l₁ l₂ = p)
+    (h₁ : l₁ = p ++ t₁) (h₂ : l₂ = p ++ t₂) : ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ t₁ ≠ [] ∧ t₂ ≠ [] ∧
+      t₁.head? ≠ t₂.head? := by
   constructor <;> intro h
-  · obtain ⟨c₁, l₁, rfl⟩ := l₁.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.1)
-    obtain ⟨c₂, l₂, rfl⟩ := l₂.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.2)
-    simp only [cons_prefix_cons, not_and] at h
-    cases Decidable.em (c₁ = c₂)
-    · subst c₂
-      simp only [forall_const] at h
-      let ⟨c₁', c₂', pre, suf₁, suf₂, hc, heq₁, heq₂⟩ :=
-        not_prefix_and_not_prefix_symm_iff_exists.mp h
-      exact ⟨c₁', c₂', c₁::pre, suf₁, suf₂, hc, by simp [heq₁], by simp [heq₂]⟩
-    · next hc =>
-      exact ⟨c₁, c₂, [], l₁, l₂, hc, nil_append .., nil_append ..⟩
-  · let ⟨c₁, c₂, pre, suf₁, suf₂, hc, heq₁, heq₂⟩ := h
-    rw [heq₁, heq₂]
-    simp [prefix_append_right_inj, cons_prefix_cons, hc, hc.symm]
+  · obtain ⟨a₁, l₁, rfl⟩ := l₁.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.1)
+    obtain ⟨a₂, l₂, rfl⟩ := l₂.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.2)
+    cases Decidable.em (a₁ = a₂)
+    · subst a₂
+      simp only [← hp, commonPrefix, ↓reduceIte, cons_append, cons.injEq, true_and] at h₁ h₂
+      simp only [cons_prefix_cons, true_and] at h
+      exact (not_prefix_and_not_prefix_symm_iff rfl h₁ h₂).mp h
+    · next hne =>
+      simp only [← hp, commonPrefix, hne, ↓reduceIte, nil_append] at h₁ h₂
+      simp [← h₁, ← h₂, hne]
+  · rw [h₁, h₂]
+    let ⟨ht₁, ht₂, hhd⟩ := h
+    obtain ⟨a₁, t₁, rfl⟩ := exists_cons_of_ne_nil ht₁
+    obtain ⟨a₂, t₂, rfl⟩ := exists_cons_of_ne_nil ht₂
+    simp only [head?_cons, ne_eq, Option.some.injEq] at hhd
+    rw [← ne_eq] at hhd
+    simp [prefix_append_right_inj, not_and_of_not_left _ hhd, not_and_of_not_left _ hhd.symm]
+termination_by l₁.length
+decreasing_by
+  rename_i _₀ _l₁ _₁ _₂ _₃ _₄ _₅ _₆ _₇ _r _₈ _₉ _₁₀ _₁₁ _₁₂ _₁₃ _₁₄ _₁₅ _₁₆ _₁₇ _₁₈ _hl₁ _₁₉ _₂₀ _₂₁
+    _₂₂ _₂₃ _₂₄ _₂₅ _₂₆ _₂₇
+  clear _₀ _₁ _₂ _₃ _₄ _₅ _₆ _₇ _r _₈ _₉ _₁₀ _₁₁ _₁₂ _₁₃ _₁₄ _₁₅ _₁₆ _₁₇ _₁₈ _₁₉ _₂₀ _₂₁ _₂₂ _₂₃ _₂₄
+    _₂₅ _₂₆ _₂₇
+  subst _l₁
+  simp
 
 end
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -528,17 +528,8 @@ theorem commonPrefix_prefix_left (l₁ l₂ : List α) : commonPrefix l₁ l₂ 
       simp [h]
 
 theorem commonPrefix_prefix_right (l₁ l₂ : List α) : commonPrefix l₁ l₂ <+: l₂ := by
-   match l₁, l₂ with
-  | [],   _  => simp [commonPrefix]
-  | _::_, [] => simp [commonPrefix]
-  | a₁::l₁, a₂::l₂ =>
-    simp only [commonPrefix]
-    cases Decidable.em (a₁ = a₂)
-    · next h =>
-      simp only [h, ↓reduceIte, cons_prefix_cons, true_and]
-      apply commonPrefix_prefix_right
-    · next h =>
-      simp [h]
+  rw [commonPrefix_comm]
+  apply commonPrefix_prefix_left
 
 theorem commonPrefix_append_append (p l₁ l₂ : List α) :
     commonPrefix (p ++ l₁) (p ++ l₂) = p ++ commonPrefix l₁ l₂ := by
@@ -546,35 +537,14 @@ theorem commonPrefix_append_append (p l₁ l₂ : List α) :
   | []   => rfl
   | a::p => simpa [commonPrefix] using commonPrefix_append_append p l₁ l₂
 
-theorem not_prefix_and_not_prefix_symm_iff {l₁ l₂ p t₁ t₂ : List α} (hp : commonPrefix l₁ l₂ = p)
-    (h₁ : l₁ = p ++ t₁) (h₂ : l₂ = p ++ t₂) : ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ t₁ ≠ [] ∧ t₂ ≠ [] ∧
-      t₁.head? ≠ t₂.head? := by
-  constructor <;> intro h
-  · obtain ⟨a₁, l₁, rfl⟩ := l₁.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.1)
-    obtain ⟨a₂, l₂, rfl⟩ := l₂.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.2)
-    cases Decidable.em (a₁ = a₂)
-    · subst a₂
-      simp only [← hp, commonPrefix, ↓reduceIte, cons_append, cons.injEq, true_and] at h₁ h₂
-      simp only [cons_prefix_cons, true_and] at h
-      exact (not_prefix_and_not_prefix_symm_iff rfl h₁ h₂).mp h
-    · next hne =>
-      simp only [← hp, commonPrefix, hne, ↓reduceIte, nil_append] at h₁ h₂
-      simp [← h₁, ← h₂, hne]
-  · rw [h₁, h₂]
-    let ⟨ht₁, ht₂, hhd⟩ := h
-    obtain ⟨a₁, t₁, rfl⟩ := exists_cons_of_ne_nil ht₁
-    obtain ⟨a₂, t₂, rfl⟩ := exists_cons_of_ne_nil ht₂
-    simp only [head?_cons, ne_eq, Option.some.injEq] at hhd
-    rw [← ne_eq] at hhd
-    simp [prefix_append_right_inj, not_and_of_not_left _ hhd, not_and_of_not_left _ hhd.symm]
-termination_by l₁.length
-decreasing_by
-  rename_i _₀ _l₁ _₁ _₂ _₃ _₄ _₅ _₆ _₇ _r _₈ _₉ _₁₀ _₁₁ _₁₂ _₁₃ _₁₄ _₁₅ _₁₆ _₁₇ _₁₈ _hl₁ _₁₉ _₂₀ _₂₁
-    _₂₂ _₂₃ _₂₄ _₂₅ _₂₆ _₂₇
-  clear _₀ _₁ _₂ _₃ _₄ _₅ _₆ _₇ _r _₈ _₉ _₁₀ _₁₁ _₁₂ _₁₃ _₁₄ _₁₅ _₁₆ _₁₇ _₁₈ _₁₉ _₂₀ _₂₁ _₂₂ _₂₃ _₂₄
-    _₂₅ _₂₆ _₂₇
-  subst _l₁
-  simp
+theorem not_prefix_and_not_prefix_symm_iff {l₁ l₂ : List α} (hp : commonPrefix l₁ l₂ = []) :
+    ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ l₁ ≠ [] ∧ l₂ ≠ [] ∧ l₁.head? ≠ l₂.head? := by
+  match l₁, l₂ with
+  | [], _  => simp
+  | _,  [] => simp
+  | a₁::l₁, a₂::l₂ =>
+    simp only [commonPrefix, ite_eq_right_iff, reduceCtorEq, imp_false] at hp
+    simp [hp, Ne.symm hp]
 
 end
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -504,6 +504,48 @@ section
 
 variable [DecidableEq α]
 
+/-- Returns the longest common prefix of two lists. -/
+def commonPrefix : (l₁ l₂ : List α) → List α
+  | [], _ => []
+  | _, [] => []
+  | a₁::l₁, a₂::l₂ =>
+    if a₁ = a₂ then
+      a₁ :: (commonPrefix l₁ l₂)
+    else
+      []
+
+theorem commonPrefix_prefix_left (l₁ l₂ : List α) : commonPrefix l₁ l₂ <+: l₁ := by
+  match l₁, l₂ with
+  | [],   _  => simp [commonPrefix]
+  | _::_, [] => simp [commonPrefix]
+  | a₁::l₁, a₂::l₂ =>
+    simp only [commonPrefix]
+    cases Decidable.em (a₁ = a₂)
+    · next h =>
+      simp only [h, ↓reduceIte, cons_prefix_cons, true_and]
+      apply commonPrefix_prefix_left
+    · next h =>
+      simp [h]
+
+theorem commonPrefix_prefix_right (l₁ l₂ : List α) : commonPrefix l₁ l₂ <+: l₂ := by
+   match l₁, l₂ with
+  | [],   _  => simp [commonPrefix]
+  | _::_, [] => simp [commonPrefix]
+  | a₁::l₁, a₂::l₂ =>
+    simp only [commonPrefix]
+    cases Decidable.em (a₁ = a₂)
+    · next h =>
+      simp only [h, ↓reduceIte, cons_prefix_cons, true_and]
+      apply commonPrefix_prefix_right
+    · next h =>
+      simp [h]
+
+theorem commonPrefix_append_append (p l₁ l₂ : List α) :
+    commonPrefix (p ++ l₁) (p ++ l₂) = p ++ commonPrefix l₁ l₂ := by
+  match p with
+  | []   => rfl
+  | a::p => simpa [commonPrefix] using commonPrefix_append_append p l₁ l₂
+
 theorem not_prefix_and_not_prefix_symm_iff_exists {l₁ l₂ : List α} :
     ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ ∃ c₁ c₂ pre suf₁ suf₂, c₁ ≠ c₂ ∧ l₁ = pre ++ c₁ :: suf₁ ∧
       l₂ = pre ++ c₂ :: suf₂ := by

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -19,6 +19,11 @@ namespace List
 
 @[deprecated (since := "2024-08-15")] alias isEmpty_iff_eq_nil := isEmpty_iff
 
+/-! ### head and tail -/
+
+theorem head_cons_tail : ∀ l h, @head α l h :: l.tail = l
+  | _::_, _ => rfl
+
 /-! ### next? -/
 
 @[simp] theorem next?_nil : @next? α [] = none := rfl
@@ -481,6 +486,12 @@ theorem Sublist.erase_diff_erase_sublist {a : α} :
       exact (erase_cons_head b _ ▸ h.erase b).erase_diff_erase_sublist
 
 end Diff
+
+/-! ### prefix, suffix, infix -/
+
+theorem ne_nil_of_not_prefix (h : ¬l₁ <+: l₂) : l₁ ≠ [] := by
+  intro heq
+  simp [heq, nil_prefix] at h
 
 /-! ### drop -/
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -520,7 +520,7 @@ theorem commonPrefix_prefix_left (l₁ l₂ : List α) : commonPrefix l₁ l₂ 
   | _::_, [] => simp [commonPrefix]
   | a₁::l₁, a₂::l₂ =>
     simp only [commonPrefix]
-    cases Decidable.em (a₁ = a₂)
+    split
     · next h =>
       simp only [h, ↓reduceIte, cons_prefix_cons, true_and]
       apply commonPrefix_prefix_left

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -21,7 +21,7 @@ namespace List
 
 /-! ### head and tail -/
 
-theorem head_cons_tail : ∀ l h, @head α l h :: l.tail = l
+theorem head_cons_tail : ∀ (l : List α) (hne : l ≠ []), l.head hne :: l.tail = l
   | _::_, _ => rfl
 
 theorem singleton_head_eq_self (l : List α) (hne : l ≠ []) (htl : l.tail = []) :

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -500,7 +500,11 @@ theorem ne_nil_of_not_prefix (h : ¬l₁ <+: l₂) : l₁ ≠ [] := by
   intro heq
   simp [heq, nil_prefix] at h
 
-theorem not_prefix_and_not_prefix_symm_iff_exists [DecidableEq α] {l₁ l₂ : List α} :
+section
+
+variable [DecidableEq α]
+
+theorem not_prefix_and_not_prefix_symm_iff_exists {l₁ l₂ : List α} :
     ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ ∃ c₁ c₂ pre suf₁ suf₂, c₁ ≠ c₂ ∧ l₁ = pre ++ c₁ :: suf₁ ∧
       l₂ = pre ++ c₂ :: suf₂ := by
   constructor <;> intro h
@@ -518,6 +522,8 @@ theorem not_prefix_and_not_prefix_symm_iff_exists [DecidableEq α] {l₁ l₂ : 
   · let ⟨c₁, c₂, pre, suf₁, suf₂, hc, heq₁, heq₂⟩ := h
     rw [heq₁, heq₂]
     simp [prefix_append_right_inj, cons_prefix_cons, hc, hc.symm]
+
+end
 
 /-! ### drop -/
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -504,16 +504,6 @@ section
 
 variable [DecidableEq α]
 
-/-- Returns the longest common prefix of two lists. -/
-def commonPrefix : (l₁ l₂ : List α) → List α
-  | [], _ => []
-  | _, [] => []
-  | a₁::l₁, a₂::l₂ =>
-    if a₁ = a₂ then
-      a₁ :: (commonPrefix l₁ l₂)
-    else
-      []
-
 theorem commonPrefix_prefix_left (l₁ l₂ : List α) : commonPrefix l₁ l₂ <+: l₁ := by
   match l₁, l₂ with
   | [],   _  => simp [commonPrefix]

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -500,9 +500,9 @@ theorem ne_nil_of_not_prefix (h : ¬l₁ <+: l₂) : l₁ ≠ [] := by
   intro heq
   simp [heq, nil_prefix] at h
 
-theorem not_prefix_and_not_prefix_symm_iff_exists [BEq α] [LawfulBEq α] [DecidableEq α]
-    {l₁ l₂ : List α} : ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ ∃ c₁ c₂ pre suf₁ suf₂, c₁ ≠ c₂ ∧
-      l₁ = pre ++ c₁ :: suf₁ ∧ l₂ = pre ++ c₂ :: suf₂ := by
+theorem not_prefix_and_not_prefix_symm_iff_exists [DecidableEq α] {l₁ l₂ : List α} :
+    ¬l₁ <+: l₂ ∧ ¬l₂ <+: l₁ ↔ ∃ c₁ c₂ pre suf₁ suf₂, c₁ ≠ c₂ ∧ l₁ = pre ++ c₁ :: suf₁ ∧
+      l₂ = pre ++ c₂ :: suf₂ := by
   constructor <;> intro h
   · obtain ⟨c₁, l₁, rfl⟩ := l₁.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.1)
     obtain ⟨c₂, l₂, rfl⟩ := l₂.exists_cons_of_ne_nil (ne_nil_of_not_prefix h.2)


### PR DESCRIPTION
* Add 'leftover' lemmas I created while trying to prove
  `String.splitOn_of_valid`. See
  https://github.com/leanprover-community/batteries/pull/743.
* Add the function `List.commonPrefix` and its lemmas. It returns the
  longest common prefix of two lists.