### PR TITLE
feat: add lemmas about lists

### DIFF
--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -19,6 +19,11 @@ namespace List
 
 @[deprecated (since := "2024-08-15")] alias isEmpty_iff_eq_nil := isEmpty_iff
 
+/-! ### head and tail -/
+
+theorem head_cons_tail : ∀ (l : List α) (hne : l ≠ []), l.head hne :: l.tail = l
+  | _::_, _ => rfl
+
 /-! ### next? -/
 
 @[simp] theorem next?_nil : @next? α [] = none := rfl
@@ -481,6 +486,12 @@ theorem Sublist.erase_diff_erase_sublist {a : α} :
       exact (erase_cons_head b _ ▸ h.erase b).erase_diff_erase_sublist
 
 end Diff
+
+/-! ### prefix, suffix, infix -/
+
+theorem ne_nil_of_not_prefix (h : ¬l₁ <+: l₂) : l₁ ≠ [] := by
+  intro heq
+  simp [heq, nil_prefix] at h
 
 /-! ### drop -/
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -24,6 +24,10 @@ namespace List
 theorem head_cons_tail : ∀ (l : List α) (hne : l ≠ []), l.head hne :: l.tail = l
   | _::_, _ => rfl
 
+theorem singleton_head_eq_self (l : List α) (hne : l ≠ []) (htl : l.tail = []) :
+    [l.head hne] = l := by
+  conv => rhs; rw [← head_cons_tail l hne, htl]
+
 /-! ### next? -/
 
 @[simp] theorem next?_nil : @next? α [] = none := rfl
@@ -488,6 +492,9 @@ theorem Sublist.erase_diff_erase_sublist {a : α} :
 end Diff
 
 /-! ### prefix, suffix, infix -/
+
+theorem singleton_prefix_cons (a) : [a] <+: a :: l :=
+  (prefix_cons_inj a).mpr nil_prefix
 
 theorem ne_nil_of_not_prefix (h : ¬l₁ <+: l₂) : l₁ ≠ [] := by
   intro heq


### PR DESCRIPTION
These are 'leftover' lemmas I created while trying to prove
`String.splitOn_of_valid`. See
https://github.com/leanprover-community/batteries/pull/743.

Co-authored-by: François G. Dorais <fgdorais@gmail.com>

---

This is the second version of #987.