### PR TITLE
fix: print prefix bug

### DIFF
--- a/Batteries/Tactic/PrintPrefix.lean
+++ b/Batteries/Tactic/PrintPrefix.lean
@@ -108,12 +108,9 @@ by setting `showTypes` to `false`:
 The complete set of flags can be seen in the documentation
 for `Lean.Elab.Command.PrintPrefixConfig`.
 -/
-elab (name := printPrefix) tk:"#print " colGt &"prefix"
+elab (name := printPrefix) tk:"#print " colGt "prefix"
     cfg:(Lean.Parser.Tactic.config)? name:(ident)? : command => liftTermElabM do
-  match name with
-  | none =>
-    logInfoAt tk "unexpected end of input; expected identifier or string literal"
-  | some name =>
+  if let some name := name then
     let opts ← elabPrintPrefixConfig (mkOptionalNode cfg)
     let mut msgs ← matchingConstants opts name.getId
     if msgs.isEmpty then

--- a/Batteries/Tactic/PrintPrefix.lean
+++ b/Batteries/Tactic/PrintPrefix.lean
@@ -108,12 +108,15 @@ by setting `showTypes` to `false`:
 The complete set of flags can be seen in the documentation
 for `Lean.Elab.Command.PrintPrefixConfig`.
 -/
-elab (name := printPrefix) "#print" tk:"prefix"
-    cfg:(Lean.Parser.Tactic.config)? name:ident : command => liftTermElabM do
-  let nameId := name.getId
-  let opts ← elabPrintPrefixConfig (mkOptionalNode cfg)
-  let mut msgs ← matchingConstants opts nameId
-  if msgs.isEmpty then
-    if let [name] ← resolveGlobalConst name then
-      msgs ← matchingConstants opts name
-  logInfoAt tk (.joinSep msgs.toList "")
+elab (name := printPrefix) tk:"#print " colGt &"prefix"
+    cfg:(Lean.Parser.Tactic.config)? name:(ident)? : command => liftTermElabM do
+  match name with
+  | none =>
+    logInfoAt tk "unexpected end of input; expected identifier or string literal"
+  | some name =>
+    let opts ← elabPrintPrefixConfig (mkOptionalNode cfg)
+    let mut msgs ← matchingConstants opts name.getId
+    if msgs.isEmpty then
+      if let [name] ← resolveGlobalConst name then
+        msgs ← matchingConstants opts name
+    logInfoAt tk (.joinSep msgs.toList "")

--- a/test/print_prefix.lean
+++ b/test/print_prefix.lean
@@ -172,6 +172,5 @@ TestInd.toCtorIdx : TestInd → Nat
 #guard_msgs in
 #print prefix TestInd
 
-/-- info: unexpected end of input; expected identifier or string literal -/
-#guard_msgs in
+-- `#print prefix` does nothing if no identifier is provided
 #print prefix

--- a/test/print_prefix.lean
+++ b/test/print_prefix.lean
@@ -171,3 +171,7 @@ TestInd.toCtorIdx : TestInd → Nat
 -/
 #guard_msgs in
 #print prefix TestInd
+
+/-- info: unexpected end of input; expected identifier or string literal -/
+#guard_msgs in
+#print prefix

--- a/test/print_prefix.lean
+++ b/test/print_prefix.lean
@@ -173,4 +173,5 @@ TestInd.toCtorIdx : TestInd → Nat
 #print prefix TestInd
 
 -- `#print prefix` does nothing if no identifier is provided
+#guard_msgs in
 #print prefix


### PR DESCRIPTION
This fix makes it so that `#print prefix` does nothing when there is no identifier. Note that this doesn't actually fix the underlying issue: `#print prefix` is still horribly slow downstream of Mathlib.

Closes #995