### PR TITLE
fix: make `proof_wanted` not report unused variables

### DIFF
--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -33,7 +33,10 @@ elaboration, but it's then removed from the environment.
 def elabProofWanted : CommandElab
   | `($mods:declModifiers proof_wanted $name $args* : $res) => withoutModifyingEnv do
     -- The helper axiom is used instead of `sorry` to avoid spurious warnings
-    elabCommand <| ← `(axiom helper (p : Prop) : p
-                       $mods:declModifiers
-                       theorem $name $args* : $res := helper _)
+    elabCommand <| ← `(
+      section
+      set_option linter.unusedVariables false
+      axiom helper {α : Sort _} : α
+      $mods:declModifiers theorem $name $args* : $res := helper
+      end)
   | _ => throwUnsupportedSyntax

--- a/test/proof_wanted.lean
+++ b/test/proof_wanted.lean
@@ -1,0 +1,15 @@
+import Batteries.Util.ProofWanted
+
+/-!
+No unused variable warnings.
+-/
+#guard_msgs in proof_wanted foo (x : Nat) : True
+
+/-!
+When not a proposition, rely on `theorem` command failing.
+-/
+/--
+error: type of theorem 'foo' is not a proposition
+  Nat → Nat
+-/
+#guard_msgs in proof_wanted foo (x : Nat) : Nat


### PR DESCRIPTION
This was requested by Terence Tao [on Zulip](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/Is.20a.20.60definition_wanted.60.20keyword.20possible.3F/near/477325788)

Closes #938