### PR TITLE
chore: rename List.modifyNth->modify and insertNth->insertIdx

### DIFF
--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -170,10 +170,12 @@ using `f` if the index is larger than the length of the List.
 modifyNthTail f 2 [a, b, c] = [a, b] ++ f [c]
 ```
 -/
-@[simp] def modifyNthTail (f : List α → List α) : Nat → List α → List α
+@[simp] def modifyTailIdx (f : List α → List α) : Nat → List α → List α
   | 0, l => f l
   | _+1, [] => []
-  | n+1, a :: l => a :: modifyNthTail f n l
+  | n+1, a :: l => a :: modifyTailIdx f n l
+
+@[deprecated (since := "2024-10-21")] alias modifyNthTail := modifyTailIdx
 
 /-- Apply `f` to the head of the list, if it exists. -/
 @[inline] def modifyHead (f : α → α) : List α → List α
@@ -185,25 +187,29 @@ modifyNthTail f 2 [a, b, c] = [a, b] ++ f [c]
 @[simp] theorem modifyHead_cons (a : α) (l : List α) (f : α → α) :
     (a :: l).modifyHead f = f a :: l := by rw [modifyHead]
 
-/-- Apply `f` to the nth element of the list, if it exists. -/
-def modifyNth (f : α → α) : Nat → List α → List α :=
-  modifyNthTail (modifyHead f)
+/--
+Apply `f` to the nth element of the list, if it exists, replacing that element with the result.
+-/
+def modify (f : α → α) : Nat → List α → List α :=
+  modifyTailIdx (modifyHead f)
 
-/-- Tail-recursive version of `modifyNth`. -/
-def modifyNthTR (f : α → α) (n : Nat) (l : List α) : List α := go l n #[] where
-  /-- Auxiliary for `modifyNthTR`: `modifyNthTR.go f l n acc = acc.toList ++ modifyNth f n l`. -/
+@[deprecated (since := "2024-10-21")] alias modifyNth := modify
+
+/-- Tail-recursive version of `modify`. -/
+def modifyTR (f : α → α) (n : Nat) (l : List α) : List α := go l n #[] where
+  /-- Auxiliary for `modifyTR`: `modifyTR.go f l n acc = acc.toList ++ modify f n l`. -/
   go : List α → Nat → Array α → List α
   | [], _, acc => acc.toList
   | a :: l, 0, acc => acc.toListAppend (f a :: l)
   | a :: l, n+1, acc => go l n (acc.push a)
 
-theorem modifyNthTR_go_eq : ∀ l n, modifyNthTR.go f l n acc = acc.toList ++ modifyNth f n l
-  | [], n => by cases n <;> simp [modifyNthTR.go, modifyNth]
-  | a :: l, 0 => by simp [modifyNthTR.go, modifyNth]
-  | a :: l, n+1 => by simp [modifyNthTR.go, modifyNth, modifyNthTR_go_eq l]
+theorem modifyTR_go_eq : ∀ l n, modifyTR.go f l n acc = acc.toList ++ modify f n l
+  | [], n => by cases n <;> simp [modifyTR.go, modify]
+  | a :: l, 0 => by simp [modifyTR.go, modify]
+  | a :: l, n+1 => by simp [modifyTR.go, modify, modifyTR_go_eq l]
 
-@[csimp] theorem modifyNth_eq_modifyNthTR : @modifyNth = @modifyNthTR := by
-  funext α f n l; simp [modifyNthTR, modifyNthTR_go_eq]
+@[csimp] theorem modify_eq_modifyTR : @modify = @modifyTR := by
+  funext α f n l; simp [modifyTR, modifyTR_go_eq]
 
 /-- Apply `f` to the last element of `l`, if it exists. -/
 @[inline] def modifyLast (f : α → α) (l : List α) : List α := go l #[] where
@@ -219,23 +225,25 @@ theorem modifyNthTR_go_eq : ∀ l n, modifyNthTR.go f l n acc = acc.toList ++ mo
 insertNth 2 1 [1, 2, 3, 4] = [1, 2, 1, 3, 4]
 ```
 -/
-def insertNth (n : Nat) (a : α) : List α → List α :=
-  modifyNthTail (cons a) n
+def insertIdx (n : Nat) (a : α) : List α → List α :=
+  modifyTailIdx (cons a) n
 
-/-- Tail-recursive version of `insertNth`. -/
-@[inline] def insertNthTR (n : Nat) (a : α) (l : List α) : List α := go n l #[] where
-  /-- Auxiliary for `insertNthTR`: `insertNthTR.go a n l acc = acc.toList ++ insertNth n a l`. -/
+@[deprecated (since := "2024-10-21")] alias insertNth := insertIdx
+
+/-- Tail-recursive version of `insertIdx`. -/
+@[inline] def insertIdxTR (n : Nat) (a : α) (l : List α) : List α := go n l #[] where
+  /-- Auxiliary for `insertIdxTR`: `insertIdxTR.go a n l acc = acc.toList ++ insertIdx n a l`. -/
   go : Nat → List α → Array α → List α
   | 0, l, acc => acc.toListAppend (a :: l)
   | _, [], acc => acc.toList
   | n+1, a :: l, acc => go n l (acc.push a)
 
-theorem insertNthTR_go_eq : ∀ n l, insertNthTR.go a n l acc = acc.toList ++ insertNth n a l
-  | 0, l | _+1, [] => by simp [insertNthTR.go, insertNth]
-  | n+1, a :: l => by simp [insertNthTR.go, insertNth, insertNthTR_go_eq n l]
+theorem insertIdxTR_go_eq : ∀ n l, insertIdxTR.go a n l acc = acc.toList ++ insertIdx n a l
+  | 0, l | _+1, [] => by simp [insertIdxTR.go, insertIdx]
+  | n+1, a :: l => by simp [insertIdxTR.go, insertIdx, insertIdxTR_go_eq n l]
 
-@[csimp] theorem insertNth_eq_insertNthTR : @insertNth = @insertNthTR := by
-  funext α f n l; simp [insertNthTR, insertNthTR_go_eq]
+@[csimp] theorem insertIdx_eq_insertIdxTR : @insertIdx = @insertIdxTR := by
+  funext α f n l; simp [insertIdxTR, insertIdxTR_go_eq]
 
 theorem headD_eq_head? (l) (a : α) : headD l a = (head? l).getD a := by cases l <;> rfl
 

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -15,10 +15,6 @@ namespace List
 @[simp] theorem getElem_mk {xs : List α} {i : Nat} (h : i < xs.length) :
     (Array.mk xs)[i] = xs[i] := rfl
 
-/-! ### isEmpty -/
-
-@[deprecated (since := "2024-08-15")] alias isEmpty_iff_eq_nil := isEmpty_iff
-
 /-! ### next? -/
 
 @[simp] theorem next?_nil : @next? α [] = none := rfl
@@ -40,172 +36,113 @@ theorem dropLast_eq_eraseIdx {xs : List α} {i : Nat} (last_idx : i + 1 = xs.len
     exact ih last_idx
     exact fun _ => nomatch xs
 
-/-! ### get? -/
-
-@[deprecated getElem_eq_iff (since := "2024-06-12")]
-theorem get_eq_iff : List.get l n = x ↔ l.get? n.1 = some x := by
-  simp
-
-@[deprecated getElem?_inj (since := "2024-06-12")]
-theorem get?_inj
-    (h₀ : i < xs.length) (h₁ : Nodup xs) (h₂ : xs.get? i = xs.get? j) : i = j := by
-  apply getElem?_inj h₀ h₁
-  simp_all
-
 /-! ### modifyHead -/
 
 @[simp] theorem modifyHead_modifyHead (l : List α) (f g : α → α) :
     (l.modifyHead f).modifyHead g = l.modifyHead (g ∘ f) := by cases l <;> simp [modifyHead]
 
-/-! ### modifyNth -/
+/-! ### modify -/
 
-@[simp] theorem modifyNth_nil (f : α → α) (n) : [].modifyNth f n = [] := by cases n <;> rfl
+@[simp] theorem modify_nil (f : α → α) (n) : [].modify f n = [] := by cases n <;> rfl
 
-@[simp] theorem modifyNth_zero_cons (f : α → α) (a : α) (l : List α) :
-    (a :: l).modifyNth f 0 = f a :: l := rfl
+@[simp] theorem modify_zero_cons (f : α → α) (a : α) (l : List α) :
+    (a :: l).modify f 0 = f a :: l := rfl
 
-@[simp] theorem modifyNth_succ_cons (f : α → α) (a : α) (l : List α) (n) :
-    (a :: l).modifyNth f (n + 1) = a :: l.modifyNth f n := by rfl
+@[simp] theorem modify_succ_cons (f : α → α) (a : α) (l : List α) (n) :
+    (a :: l).modify f (n + 1) = a :: l.modify f n := by rfl
 
-theorem modifyNthTail_id : ∀ n (l : List α), l.modifyNthTail id n = l
+theorem modifyTailIdx_id : ∀ n (l : List α), l.modifyTailIdx id n = l
   | 0, _ => rfl
   | _+1, [] => rfl
-  | n+1, a :: l => congrArg (cons a) (modifyNthTail_id n l)
+  | n+1, a :: l => congrArg (cons a) (modifyTailIdx_id n l)
 
-theorem eraseIdx_eq_modifyNthTail : ∀ n (l : List α), eraseIdx l n = modifyNthTail tail n l
+theorem eraseIdx_eq_modifyTailIdx : ∀ n (l : List α), eraseIdx l n = modifyTailIdx tail n l
   | 0, l => by cases l <;> rfl
   | _+1, [] => rfl
-  | _+1, _ :: _ => congrArg (cons _) (eraseIdx_eq_modifyNthTail _ _)
+  | _+1, _ :: _ => congrArg (cons _) (eraseIdx_eq_modifyTailIdx _ _)
 
-@[deprecated (since := "2024-05-06")] alias removeNth_eq_nth_tail := eraseIdx_eq_modifyNthTail
-
-theorem getElem?_modifyNth (f : α → α) :
-    ∀ n (l : List α) m, (modifyNth f n l)[m]? = (fun a => if n = m then f a else a) <$> l[m]?
+theorem getElem?_modify (f : α → α) :
+    ∀ n (l : List α) m, (modify f n l)[m]? = (fun a => if n = m then f a else a) <$> l[m]?
   | n, l, 0 => by cases l <;> cases n <;> simp
   | n, [], _+1 => by cases n <;> rfl
-  | 0, _ :: l, m+1 => by cases h : l[m]? <;> simp [h, modifyNth, m.succ_ne_zero.symm]
+  | 0, _ :: l, m+1 => by cases h : l[m]? <;> simp [h, modify, m.succ_ne_zero.symm]
   | n+1, a :: l, m+1 => by
-    simp only [modifyNth_succ_cons, getElem?_cons_succ, Nat.reduceEqDiff, Option.map_eq_map]
-    refine (getElem?_modifyNth f n l m).trans ?_
+    simp only [modify_succ_cons, getElem?_cons_succ, Nat.reduceEqDiff, Option.map_eq_map]
+    refine (getElem?_modify f n l m).trans ?_
     cases h' : l[m]? <;> by_cases h : n = m <;>
       simp [h, if_pos, if_neg, Option.map, mt Nat.succ.inj, not_false_iff, h']
 
-@[deprecated getElem?_modifyNth (since := "2024-06-12")]
-theorem get?_modifyNth (f : α → α) (n) (l : List α) (m) :
-    (modifyNth f n l).get? m = (fun a => if n = m then f a else a) <$> l.get? m := by
-  simp [getElem?_modifyNth]
-
-theorem length_modifyNthTail (f : List α → List α) (H : ∀ l, length (f l) = length l) :
-    ∀ n l, length (modifyNthTail f n l) = length l
+theorem length_modifyTailIdx (f : List α → List α) (H : ∀ l, length (f l) = length l) :
+    ∀ n l, length (modifyTailIdx f n l) = length l
   | 0, _ => H _
   | _+1, [] => rfl
-  | _+1, _ :: _ => congrArg (·+1) (length_modifyNthTail _ H _ _)
+  | _+1, _ :: _ => congrArg (·+1) (length_modifyTailIdx _ H _ _)
 
-@[deprecated (since := "2024-06-07")] alias modifyNthTail_length := length_modifyNthTail
-
-theorem modifyNthTail_add (f : List α → List α) (n) (l₁ l₂ : List α) :
-    modifyNthTail f (l₁.length + n) (l₁ ++ l₂) = l₁ ++ modifyNthTail f n l₂ := by
+theorem modifyTailIdx_add (f : List α → List α) (n) (l₁ l₂ : List α) :
+    modifyTailIdx f (l₁.length + n) (l₁ ++ l₂) = l₁ ++ modifyTailIdx f n l₂ := by
   induction l₁ <;> simp [*, Nat.succ_add]
 
-theorem exists_of_modifyNthTail (f : List α → List α) {n} {l : List α} (h : n ≤ l.length) :
-    ∃ l₁ l₂, l = l₁ ++ l₂ ∧ l₁.length = n ∧ modifyNthTail f n l = l₁ ++ f l₂ :=
+theorem exists_of_modifyTailIdx (f : List α → List α) {n} {l : List α} (h : n ≤ l.length) :
+    ∃ l₁ l₂, l = l₁ ++ l₂ ∧ l₁.length = n ∧ modifyTailIdx f n l = l₁ ++ f l₂ :=
   have ⟨_, _, eq, hl⟩ : ∃ l₁ l₂, l = l₁ ++ l₂ ∧ l₁.length = n :=
     ⟨_, _, (take_append_drop n l).symm, length_take_of_le h⟩
-  ⟨_, _, eq, hl, hl ▸ eq ▸ modifyNthTail_add (n := 0) ..⟩
+  ⟨_, _, eq, hl, hl ▸ eq ▸ modifyTailIdx_add (n := 0) ..⟩
 
-@[simp] theorem length_modifyNth (f : α → α) : ∀ n l, length (modifyNth f n l) = length l :=
-  length_modifyNthTail _ fun l => by cases l <;> rfl
+@[simp] theorem length_modify (f : α → α) : ∀ n l, length (modify f n l) = length l :=
+  length_modifyTailIdx _ fun l => by cases l <;> rfl
 
-@[deprecated (since := "2024-06-07")] alias modify_get?_length := length_modifyNth
+@[simp] theorem getElem?_modify_eq (f : α → α) (n) (l : List α) :
+    (modify f n l)[n]? = f <$> l[n]? := by
+  simp only [getElem?_modify, if_pos]
 
-@[simp] theorem getElem?_modifyNth_eq (f : α → α) (n) (l : List α) :
-    (modifyNth f n l)[n]? = f <$> l[n]? := by
-  simp only [getElem?_modifyNth, if_pos]
+@[simp] theorem getElem?_modify_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
+    (modify f m l)[n]? = l[n]? := by
+  simp only [getElem?_modify, if_neg h, id_map']
 
-@[deprecated getElem?_modifyNth_eq (since := "2024-06-12")]
-theorem get?_modifyNth_eq (f : α → α) (n) (l : List α) :
-    (modifyNth f n l).get? n = f <$> l.get? n := by
-  simp [getElem?_modifyNth_eq]
-
-@[simp] theorem getElem?_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
-    (modifyNth f m l)[n]? = l[n]? := by
-  simp only [getElem?_modifyNth, if_neg h, id_map']
-
-@[deprecated getElem?_modifyNth_ne (since := "2024-06-12")]
-theorem get?_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
-    (modifyNth f m l).get? n = l.get? n := by
-  simp [h]
-
-theorem exists_of_modifyNth (f : α → α) {n} {l : List α} (h : n < l.length) :
-    ∃ l₁ a l₂, l = l₁ ++ a :: l₂ ∧ l₁.length = n ∧ modifyNth f n l = l₁ ++ f a :: l₂ :=
-  match exists_of_modifyNthTail _ (Nat.le_of_lt h) with
+theorem exists_of_modify (f : α → α) {n} {l : List α} (h : n < l.length) :
+    ∃ l₁ a l₂, l = l₁ ++ a :: l₂ ∧ l₁.length = n ∧ modify f n l = l₁ ++ f a :: l₂ :=
+  match exists_of_modifyTailIdx _ (Nat.le_of_lt h) with
   | ⟨_, _::_, eq, hl, H⟩ => ⟨_, _, _, eq, hl, H⟩
   | ⟨_, [], eq, hl, _⟩ => nomatch Nat.ne_of_gt h (eq ▸ append_nil _ ▸ hl)
 
-theorem modifyNthTail_eq_take_drop (f : List α → List α) (H : f [] = []) :
-    ∀ n l, modifyNthTail f n l = take n l ++ f (drop n l)
+theorem modifyTailIdx_eq_take_drop (f : List α → List α) (H : f [] = []) :
+    ∀ n l, modifyTailIdx f n l = take n l ++ f (drop n l)
   | 0, _ => rfl
   | _ + 1, [] => H.symm
-  | n + 1, b :: l => congrArg (cons b) (modifyNthTail_eq_take_drop f H n l)
+  | n + 1, b :: l => congrArg (cons b) (modifyTailIdx_eq_take_drop f H n l)
 
-theorem modifyNth_eq_take_drop (f : α → α) :
-    ∀ n l, modifyNth f n l = take n l ++ modifyHead f (drop n l) :=
-  modifyNthTail_eq_take_drop _ rfl
+theorem modify_eq_take_drop (f : α → α) :
+    ∀ n l, modify f n l = take n l ++ modifyHead f (drop n l) :=
+  modifyTailIdx_eq_take_drop _ rfl
 
-theorem modifyNth_eq_take_cons_drop (f : α → α) {n l} (h : n < length l) :
-    modifyNth f n l = take n l ++ f l[n] :: drop (n + 1) l := by
-  rw [modifyNth_eq_take_drop, drop_eq_getElem_cons h]; rfl
+theorem modify_eq_take_cons_drop (f : α → α) {n l} (h : n < length l) :
+    modify f n l = take n l ++ f l[n] :: drop (n + 1) l := by
+  rw [modify_eq_take_drop, drop_eq_getElem_cons h]; rfl
 
 /-! ### set -/
 
-theorem set_eq_modifyNth (a : α) : ∀ n (l : List α), set l n a = modifyNth (fun _ => a) n l
+theorem set_eq_modify (a : α) : ∀ n (l : List α), set l n a = modify (fun _ => a) n l
   | 0, l => by cases l <;> rfl
   | _+1, [] => rfl
-  | _+1, _ :: _ => congrArg (cons _) (set_eq_modifyNth _ _ _)
+  | _+1, _ :: _ => congrArg (cons _) (set_eq_modify _ _ _)
 
 theorem set_eq_take_cons_drop (a : α) {n l} (h : n < length l) :
     set l n a = take n l ++ a :: drop (n + 1) l := by
-  rw [set_eq_modifyNth, modifyNth_eq_take_cons_drop _ h]
+  rw [set_eq_modify, modify_eq_take_cons_drop _ h]
 
-theorem modifyNth_eq_set_get? (f : α → α) :
-    ∀ n (l : List α), l.modifyNth f n = ((fun a => l.set n (f a)) <$> l.get? n).getD l
+theorem modify_eq_set_get? (f : α → α) :
+    ∀ n (l : List α), l.modify f n = ((fun a => l.set n (f a)) <$> l.get? n).getD l
   | 0, l => by cases l <;> rfl
   | _+1, [] => rfl
   | n+1, b :: l =>
-    (congrArg (cons _) (modifyNth_eq_set_get? ..)).trans <| by cases h : l[n]? <;> simp [h]
+    (congrArg (cons _) (modify_eq_set_get? ..)).trans <| by cases h : l[n]? <;> simp [h]
 
-theorem modifyNth_eq_set_get (f : α → α) {n} {l : List α} (h) :
-    l.modifyNth f n = l.set n (f (l.get ⟨n, h⟩)) := by
-  rw [modifyNth_eq_set_get?, get?_eq_get h]; rfl
-
--- The naming of `exists_of_set'` and `exists_of_set` have been swapped.
--- If no one complains, we will remove this version later.
-@[deprecated exists_of_set (since := "2024-07-04")]
-theorem exists_of_set' {l : List α} (h : n < l.length) :
-    ∃ l₁ a l₂, l = l₁ ++ a :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ := by
-  rw [set_eq_modifyNth]; exact exists_of_modifyNth _ h
-
-@[deprecated getElem?_set_self' (since := "2024-06-12")]
-theorem get?_set_eq (a : α) (n) (l : List α) : (set l n a).get? n = (fun _ => a) <$> l.get? n := by
-  simp only [get?_eq_getElem?, getElem?_set_self', Option.map_eq_map]
-  rfl
+theorem modify_eq_set_get (f : α → α) {n} {l : List α} (h) :
+    l.modify f n = l.set n (f (l.get ⟨n, h⟩)) := by
+  rw [modify_eq_set_get?, get?_eq_get h]; rfl
 
 theorem getElem?_set_eq_of_lt (a : α) {n} {l : List α} (h : n < length l) :
     (set l n a)[n]? = some a := by rw [getElem?_set_self', getElem?_eq_getElem h]; rfl
-
-@[deprecated getElem?_set_eq_of_lt (since := "2024-06-12")]
-theorem get?_set_eq_of_lt (a : α) {n} {l : List α} (h : n < length l) :
-    (set l n a).get? n = some a := by
-  rw [get?_eq_getElem?, getElem?_set_self', getElem?_eq_getElem h]; rfl
-
-@[deprecated getElem?_set_ne (since := "2024-06-12")]
-theorem get?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get? n = l.get? n := by
-  simp [h]
-
-@[deprecated getElem?_set (since := "2024-06-12")]
-theorem get?_set (a : α) {m n} (l : List α) :
-    (set l m a).get? n = if m = n then (fun _ => a) <$> l.get? n else l.get? n := by
-  simp [getElem?_set']; rfl
 
 theorem get?_set_of_lt (a : α) {m n} (l : List α) (h : n < length l) :
     (set l m a).get? n = if m = n then some a else l.get? n := by
@@ -214,8 +151,6 @@ theorem get?_set_of_lt (a : α) {m n} (l : List α) (h : n < length l) :
 theorem get?_set_of_lt' (a : α) {m n} (l : List α) (h : m < length l) :
     (set l m a).get? n = if m = n then some a else l.get? n := by
   simp [getElem?_set]; split <;> subst_vars <;> simp [*, getElem?_eq_getElem h]
-
-@[deprecated (since := "2024-05-06")] alias length_removeNth := length_eraseIdx
 
 /-! ### tail -/
 
@@ -235,8 +170,6 @@ theorem length_tail_add_one (l : List α) (h : 0 < length l) : (length (tail l))
   exact go #[] _ rfl
 
 /-! ### erase -/
-
-@[deprecated (since := "2024-04-22")] alias sublist.erase := Sublist.erase
 
 theorem erase_eq_self_iff_forall_bne [BEq α] (a : α) (xs : List α) :
     xs.erase a = xs ↔ ∀ (x : α), x ∈ xs → ¬x == a := by
@@ -667,3 +600,72 @@ theorem foldlM_map [Monad m] (f : β₁ → β₂) (g : α → β₂ → m α) (
 theorem foldrM_map [Monad m] [LawfulMonad m] (f : β₁ → β₂) (g : β₂ → α → m α) (l : List β₁)
     (init : α) : (l.map f).foldrM g init = l.foldrM (fun x y => g (f x) y) init := by
   induction l generalizing g init <;> simp [*]
+
+/-! ### deprecations -/
+
+@[deprecated (since := "2024-08-15")] alias isEmpty_iff_eq_nil := isEmpty_iff
+@[deprecated getElem_eq_iff (since := "2024-06-12")]
+theorem get_eq_iff : List.get l n = x ↔ l.get? n.1 = some x := by
+  simp
+@[deprecated getElem?_inj (since := "2024-06-12")]
+theorem get?_inj
+    (h₀ : i < xs.length) (h₁ : Nodup xs) (h₂ : xs.get? i = xs.get? j) : i = j := by
+  apply getElem?_inj h₀ h₁
+  simp_all
+@[deprecated (since := "2024-10-21")] alias modifyNth_nil := modify_nil
+@[deprecated (since := "2024-10-21")] alias modifyNth_zero_cons := modify_zero_cons
+@[deprecated (since := "2024-10-21")] alias modifyNth_succ_cons := modify_succ_cons
+@[deprecated (since := "2024-10-21")] alias modifyNthTail_id := modifyTailIdx_id
+@[deprecated (since := "2024-10-21")] alias eraseIdx_eq_modifyNthTail := eraseIdx_eq_modifyTailIdx
+@[deprecated (since := "2024-05-06")] alias removeNth_eq_nth_tail := eraseIdx_eq_modifyTailIdx
+@[deprecated (since := "2024-10-21")] alias getElem?_modifyNth := getElem?_modify
+@[deprecated getElem?_modify (since := "2024-06-12")]
+theorem get?_modifyNth (f : α → α) (n) (l : List α) (m) :
+    (modify f n l).get? m = (fun a => if n = m then f a else a) <$> l.get? m := by
+  simp [getElem?_modify]
+@[deprecated (since := "2024-10-21")] alias length_modifyNthTail := length_modifyTailIdx
+@[deprecated (since := "2024-06-07")] alias modifyNthTail_length := length_modifyTailIdx
+@[deprecated (since := "2024-10-21")] alias modifyNthTail_add := modifyTailIdx_add
+@[deprecated (since := "2024-10-21")] alias exists_of_modifyNthTail := exists_of_modifyTailIdx
+@[deprecated (since := "2024-10-21")] alias length_modifyNth := length_modify
+@[deprecated (since := "2024-06-07")] alias modifyNth_get?_length := length_modify
+@[deprecated (since := "2024-10-21")] alias getElem?_modifyNth_eq := getElem?_modify_eq
+@[deprecated getElem?_modify_eq (since := "2024-06-12")]
+theorem get?_modifyNth_eq (f : α → α) (n) (l : List α) :
+    (modify f n l).get? n = f <$> l.get? n := by
+  simp [getElem?_modify_eq]
+@[deprecated (since := "2024-06-12")] alias getElem?_modifyNth_ne := getElem?_modify_ne
+@[deprecated getElem?_modify_ne (since := "2024-06-12")]
+theorem get?_modifyNth_ne (f : α → α) {m n} (l : List α) (h : m ≠ n) :
+    (modify f m l).get? n = l.get? n := by
+  simp [h]
+@[deprecated (since := "2024-10-21")] alias exists_of_modifyNth := exists_of_modify
+@[deprecated (since := "2024-10-21")] alias modifyNthTail_eq_take_drop := modifyTailIdx_eq_take_drop
+@[deprecated (since := "2024-10-21")] alias modifyNth_eq_take_drop := modify_eq_take_drop
+@[deprecated (since := "2024-10-21")] alias modifyNth_eq_take_cons_drop := modify_eq_take_cons_drop
+@[deprecated (since := "2024-10-21")] alias set_eq_modifyNth := set_eq_modify
+@[deprecated (since := "2024-10-21")] alias modifyNth_eq_set_get? := modify_eq_set_get?
+@[deprecated (since := "2024-10-21")] alias modifyNth_eq_set_get := modify_eq_set_get
+-- The naming of `exists_of_set'` and `exists_of_set` have been swapped.
+-- If no one complains, we will remove this version later.
+@[deprecated exists_of_set (since := "2024-07-04")]
+theorem exists_of_set' {l : List α} (h : n < l.length) :
+    ∃ l₁ a l₂, l = l₁ ++ a :: l₂ ∧ l₁.length = n ∧ l.set n a' = l₁ ++ a' :: l₂ := by
+  rw [set_eq_modify]; exact exists_of_modify _ h
+@[deprecated getElem?_set_self' (since := "2024-06-12")]
+theorem get?_set_eq (a : α) (n) (l : List α) : (set l n a).get? n = (fun _ => a) <$> l.get? n := by
+  simp only [get?_eq_getElem?, getElem?_set_self', Option.map_eq_map]
+  rfl
+@[deprecated getElem?_set_eq_of_lt (since := "2024-06-12")]
+theorem get?_set_eq_of_lt (a : α) {n} {l : List α} (h : n < length l) :
+    (set l n a).get? n = some a := by
+  rw [get?_eq_getElem?, getElem?_set_self', getElem?_eq_getElem h]; rfl
+@[deprecated getElem?_set_ne (since := "2024-06-12")]
+theorem get?_set_ne (a : α) {m n} (l : List α) (h : m ≠ n) : (set l m a).get? n = l.get? n := by
+  simp [h]
+@[deprecated getElem?_set (since := "2024-06-12")]
+theorem get?_set (a : α) {m n} (l : List α) :
+    (set l m a).get? n = if m = n then (fun _ => a) <$> l.get? n else l.get? n := by
+  simp [getElem?_set']; rfl
+@[deprecated (since := "2024-05-06")] alias length_removeNth := length_eraseIdx
+@[deprecated (since := "2024-04-22")] alias sublist.erase := Sublist.erase

--- a/Batteries/Data/List/Perm.lean
+++ b/Batteries/Data/List/Perm.lean
@@ -275,8 +275,8 @@ theorem Subperm.cons_left {l₁ l₂ : List α} (h : l₁ <+~ l₂) (x : α) (hx
     refine h y ?_
     simpa [hy'] using hy
 
-theorem perm_insertNth {α} (x : α) (l : List α) {n} (h : n ≤ l.length) :
-    insertNth n x l ~ x :: l := by
+theorem perm_insertIdx {α} (x : α) (l : List α) {n} (h : n ≤ l.length) :
+    insertIdx n x l ~ x :: l := by
   induction l generalizing n with
   | nil =>
     cases n with
@@ -284,10 +284,12 @@ theorem perm_insertNth {α} (x : α) (l : List α) {n} (h : n ≤ l.length) :
     | succ => cases h
   | cons _ _ ih =>
     cases n with
-    | zero => simp [insertNth]
+    | zero => simp [insertIdx]
     | succ =>
-      simp only [insertNth, modifyNthTail]
+      simp only [insertIdx, modifyTailIdx]
       refine .trans (.cons _ (ih (Nat.le_of_succ_le_succ h))) (.swap ..)
+
+@[deprecated (since := "2024-10-21")] alias perm_insertNth := perm_insertIdx
 
 theorem Perm.union_right {l₁ l₂ : List α} (t₁ : List α) (h : l₁ ~ l₂) : l₁ ∪ t₁ ~ l₂ ∪ t₁ := by
   induction h with


### PR DESCRIPTION
Mathlib adaptation PR https://github.com/leanprover-community/mathlib4/pull/17985 needs delegation before this can be merged.

See zulip [discussion](https://leanprover.zulipchat.com/#narrow/channel/348111-batteries/topic/.60List.2EmodifyNth.60/near/477340629).