### PR TITLE
fix: ignore comments in `#where`

### DIFF
--- a/Batteries/Tactic/Where.lean
+++ b/Batteries/Tactic/Where.lean
@@ -53,16 +53,6 @@ private def describeOptions (opts : Options) : CommandElabM (Option MessageData)
   else
     return MessageData.joinSep lines.toList "\n"
 
-/-- `clearTrailing stx` assumes that `stx` is a `Lean.Parser.Term.bracketedBinder` syntax node.
-It replaces the trailing `SourceInfo` with a space (` `).
-This helps the `#where` command to omit embedded comments when printing out `variable`s.
--/
-def clearTrailing (stx : Syntax) : Syntax :=
-  let args := stx.getArgs
-  if let .atom t r := args.back then
-      stx.modifyArg (args.size - 1) fun _ => .atom (t.updateTrailing " ".toSubstring) r
-  else stx
-
 /-- `#where` gives a description of the global scope at this point in the module.
 This includes the namespace, `open` namespaces, `universe` and `variable` commands,
 and options set with `set_option`. -/
@@ -84,7 +74,7 @@ elab "#where" : command => do
     msg := msg.push <| "universe " ++ MessageData.joinSep levels " "
   -- Variables
   if !scope.varDecls.isEmpty then
-    let vars := scope.varDecls.map (⟨clearTrailing ·⟩)
+    let vars := scope.varDecls.map (⟨.unsetTrailing ·⟩)
     msg := msg.push <| ← `(command| variable $vars*)
   -- Options
   if let some m ← describeOptions scope.opts then

--- a/test/where.lean
+++ b/test/where.lean
@@ -71,3 +71,14 @@ open Lean.Elab.Command Batteries
 open listMap → Array.map
 -/
 #guard_msgs in #where
+
+/--
+info: open Lean Lean.Meta
+open Lean.Elab hiding TermElabM
+open Lean.Elab.Command Batteries
+open listMap → Array.map
+
+variable (a : Nat) (b : Nat)
+-/
+#guard_msgs in
+variable (a : Nat) /- a comment -/ (b : Nat) in #where


### PR DESCRIPTION
This modification removes trailing comments from `variable` declarations, when printing then with `#where`.

See [this Zulip discussion](https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/.60.23where.60.20and.20comments) for some context.