### PR TITLE
perf: inline the `Decidable (Coprime _ _)` instance

### DIFF
--- a/Batteries/Data/Nat/Gcd.lean
+++ b/Batteries/Data/Nat/Gcd.lean
@@ -19,7 +19,8 @@ See also `nat.coprime_of_dvd` and `nat.coprime_of_dvd'` to prove `nat.Coprime m 
 /-- `m` and `n` are coprime, or relatively prime, if their `gcd` is 1. -/
 @[reducible] def Coprime (m n : Nat) : Prop := gcd m n = 1
 
-instance (m n : Nat) : Decidable (Coprime m n) := inferInstanceAs (Decidable (_ = 1))
+-- if we don't inline this, then the compiler computes the GCD even if it already has it
+@[inline] instance (m n : Nat) : Decidable (Coprime m n) := inferInstanceAs (Decidable (_ = 1))
 
 theorem coprime_iff_gcd_eq_one : Coprime m n ↔ gcd m n = 1 := .rfl
 


### PR DESCRIPTION
Without this change, when faced with
```
if gcd m n = 1 then
  f (gcd m n)
else
  0
```
the compiler will fail to perform CSE and compute `gcd m n` twice, as the `Decidable` instance is inferred as the one in this PR, which obscures the implementation from the compiler.

See https://leanprover.zulipchat.com/#narrow/stream/270676-lean4/topic/Compiler.20inserts.20.60instDecidableCoprime.60.3F/near/444709593

Deleting the instance would also work.