### PR TITLE
fix: run `Lean.enableInitializersExecution`

### DIFF
--- a/scripts/runLinter.lean
+++ b/scripts/runLinter.lean
@@ -104,6 +104,7 @@ unsafe def runLinterOnModule (update : Bool) (module : Name): IO Unit := do
     readJsonFile NoLints nolintsFile
   else
     pure #[]
+  Lean.enableInitializersExecution
   withImportModules #[module, lintModule] {} (trustLevel := 1024) fun env =>
     let ctx := { fileName := "", fileMap := default }
     let state := { env }


### PR DESCRIPTION
Without this command, parsers exposed through

https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/Util/Superscript.lean#L279-L285

suddenly stop existing when the linters run, and so a crash happens when processing the syntax.

---

It's likely that this has other unintended consequences...