### PR TITLE
fix: Readme.md needs "git" token in lakefile.lean

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The "batteries included" extended library for Lean 4. This is a collection of da
 
 To use `batteries` in your project, add the following to your `lakefile.lean`:
 ```lean
-require "leanprover-community" / "batteries" @ "main"
+require "leanprover-community" / "batteries" @ git "main"
 ```
 Or add the following to your `lakefile.toml`:
 ```toml


### PR DESCRIPTION
Thank you all for this amazing library!

This is a very small edit to the readme. The `require` directive in `lakefile.lean` needs the `git` token for specifying a Git version.