### PR TITLE
fix: dependency syntax for a reservoir+git lakefile.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Or add the following to your `lakefile.toml`:
 [[require]]
 name = "batteries"
 scope = "leanprover-community"
-version = "main"
+rev = "main"
 ```
 
 Additionally, please make sure that you're using the version of Lean that the current version of `batteries` expects. The easiest way to do this is to copy the [`lean-toolchain`](./lean-toolchain) file from this repository to your project. Once you've added the dependency declaration, the command `lake update` checks out the current version of `batteries` and writes it the Lake manifest file. Don't run this command again unless you're prepared to potentially also update your Lean compiler version, as it will retrieve the latest version of dependencies and add them to the manifest.


### PR DESCRIPTION
c.f. https://github.com/leanprover/lean4/blob/4969ec9cdb9a4a6d148b46df3850cdabae3f70ae/src/lake/README.md#toml-require

Reported at https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Importing.20a.20repository.20in.20.60lakefile.2Etoml.60/near/485018063