### PR TITLE
feat: add `Nat.ofBits` and `Fin.ofBits`

### DIFF
--- a/Batteries/Data/Fin.lean
+++ b/Batteries/Data/Fin.lean
@@ -1,3 +1,4 @@
 import Batteries.Data.Fin.Basic
 import Batteries.Data.Fin.Fold
 import Batteries.Data.Fin.Lemmas
+import Batteries.Data.Fin.OfBits

--- a/Batteries/Data/Fin/OfBits.lean
+++ b/Batteries/Data/Fin/OfBits.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2025 François G. Dorais. All rights reserved.
+Released under Apache 2. license as described in the file LICENSE.
+Authors: François G. Dorais
+-/
+
+import Batteries.Data.Nat.Lemmas
+
+namespace Fin
+
+/--
+Construct an element of `Fin (2 ^ n)` from a sequence of bits (little endian).
+-/
+abbrev ofBits (f : Fin n → Bool) : Fin (2 ^ n) := ⟨Nat.ofBits f, Nat.ofBits_lt_two_pow f⟩
+
+@[simp] theorem val_ofBits (f : Fin n → Bool) : (ofBits f).val = Nat.ofBits f := rfl

--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -6,7 +6,6 @@ Authors: Leonardo de Moura, Jeremy Avigad, Mario Carneiro
 
 namespace Nat
 
-
 /--
   Recursor identical to `Nat.recOn` but uses notations `0` for `Nat.zero` and `·+1` for `Nat.succ`
 -/
@@ -103,3 +102,9 @@ where
     else
       guess
   termination_by guess
+
+/--
+Construct a natural number from a sequence of bits using little endian convention.
+-/
+@[inline] def ofBits (f : Fin n → Bool) : Nat :=
+  Fin.foldr n (fun i v => 2 * v + (f i).toNat) 0


### PR DESCRIPTION
Adds new functions `Nat.ofBits` and `Fin.ofBits` and associated lemmas.

Prequel for #1078 which adds `BitVec.ofFn`.