### PR TITLE
fix(failing build): remove now-unneeded tactics after nonterminal simp

### DIFF
--- a/Batteries/Classes/Order.lean
+++ b/Batteries/Classes/Order.lean
@@ -5,29 +5,6 @@ Authors: Mario Carneiro
 -/
 import Batteries.Tactic.SeqFocus
 
-/-! ## Ordering -/
-
-namespace Ordering
-
-@[simp] theorem swap_swap {o : Ordering} : o.swap.swap = o := by cases o <;> rfl
-
-@[simp] theorem swap_inj {o₁ o₂ : Ordering} : o₁.swap = o₂.swap ↔ o₁ = o₂ :=
-  ⟨fun h => by simpa using congrArg swap h, congrArg _⟩
-
-theorem swap_then (o₁ o₂ : Ordering) : (o₁.then o₂).swap = o₁.swap.then o₂.swap := by
-  cases o₁ <;> rfl
-
-theorem then_eq_lt {o₁ o₂ : Ordering} : o₁.then o₂ = lt ↔ o₁ = lt ∨ o₁ = eq ∧ o₂ = lt := by
-  cases o₁ <;> cases o₂ <;> decide
-
-theorem then_eq_eq {o₁ o₂ : Ordering} : o₁.then o₂ = eq ↔ o₁ = eq ∧ o₂ = eq := by
-  cases o₁ <;> simp [«then»]
-
-theorem then_eq_gt {o₁ o₂ : Ordering} : o₁.then o₂ = gt ↔ o₁ = gt ∨ o₁ = eq ∧ o₂ = gt := by
-  cases o₁ <;> cases o₂ <;> decide
-
-end Ordering
-
 namespace Batteries
 
 /-- `TotalBLE le` asserts that `le` has a total order, that is, `le a b ∨ le b a`. -/

--- a/Batteries/Data/RBMap/Lemmas.lean
+++ b/Batteries/Data/RBMap/Lemmas.lean
@@ -288,11 +288,11 @@ theorem size_eq {t : RBNode α} : t.size = t.toList.length := by
 @[simp] theorem Any_reverse {t : RBNode α} : t.reverse.Any p ↔ t.Any p := by simp [Any_def]
 
 @[simp] theorem memP_reverse {t : RBNode α} : MemP cut t.reverse ↔ MemP (cut · |>.swap) t := by
-  simp [MemP]; apply Iff.of_eq; congr; funext x; rw [← Ordering.swap_inj]; rfl
+  simp [MemP]
 
 theorem Mem_reverse [@OrientedCmp α cmp] {t : RBNode α} :
     Mem cmp x t.reverse ↔ Mem (flip cmp) x t := by
-  simp [Mem]; apply Iff.of_eq; congr; funext x; rw [OrientedCmp.symm]; rfl
+  simp; apply Iff.of_eq; congr; funext x; rw [OrientedCmp.symm]; rfl
 
 section find?
 

--- a/Batteries/Data/RBMap/Lemmas.lean
+++ b/Batteries/Data/RBMap/Lemmas.lean
@@ -292,7 +292,7 @@ theorem size_eq {t : RBNode α} : t.size = t.toList.length := by
 
 theorem Mem_reverse [@OrientedCmp α cmp] {t : RBNode α} :
     Mem cmp x t.reverse ↔ Mem (flip cmp) x t := by
-  simp; apply Iff.of_eq; congr; funext x; rw [OrientedCmp.symm]; rfl
+  simp [Mem]; apply Iff.of_eq; congr; funext x; rw [OrientedCmp.symm]; rfl
 
 section find?
 


### PR DESCRIPTION
In https://github.com/leanprover/lean4/pull/6821, new simp lemmas were added. One of the nonterminal `simp` tactics in `RBMap.lean` now closes the only remaining goal, so that the succeeding tactic failed with "no goals to be solved". The fix is to remove the obsolete code.