### PR TITLE
feat: add `LawfulBEq` instance for `Vector`

### DIFF
--- a/Batteries/Data/Array/Lemmas.lean
+++ b/Batteries/Data/Array/Lemmas.lean
@@ -61,8 +61,10 @@ where
 
 /-! ### erase -/
 
-@[simp] proof_wanted toList_erase [BEq α] {l : Array α} {a : α} :
-    (l.erase a).toList = l.toList.erase a
+@[simp] theorem toList_erase [BEq α] (l : Array α) (a : α) :
+    (l.erase a).toList = l.toList.erase a := by
+  simp only [erase, ← List.eraseIdx_indexOf_eq_erase, List.indexOf_eq_indexOf?, length_toList]
+  cases h : l.indexOf? a <;> simp [Array.indexOf?_toList, List.eraseIdx_of_length_le, *]
 
 @[simp] theorem size_eraseIdxIfInBounds (a : Array α) (i : Nat) :
     (a.eraseIdxIfInBounds i).size = if i < a.size then a.size-1 else a.size := by

--- a/Batteries/Data/Vector/Basic.lean
+++ b/Batteries/Data/Vector/Basic.lean
@@ -39,8 +39,6 @@ namespace Vector
 @[deprecated "Use `#v[]`." (since := "2024-11-27")]
 def empty (α : Type u) : Vector α 0 := #v[]
 
-proof_wanted instLawfulBEq (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n)
-
 /--
 Returns `true` when all elements of the vector are pairwise distinct using `==` for comparison.
 -/

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -292,7 +292,7 @@ instance instDecidableExistsVectorSucc (P : Vector α (n+1) → Prop)
     [Decidable (∀ (x : α) (v : Vector α n), ¬ P (v.push x))] : Decidable (∃ v, P v) :=
   decidable_of_iff (¬ ∀ v, ¬ P v) Classical.not_forall_not
 
-instance LawfulBEq (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
+instance (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
   rfl {a} := by
     simp only [(· == ·)]
     rw [mk_isEqv_mk, Array.isEqv_self_beq]

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -203,6 +203,12 @@ theorem toArray_mk (a : Array α) (h : a.size = n) : (Vector.mk a h).toArray = a
 @[simp] theorem toArray_zipWith (f : α → β → γ) (a : Vector α n) (b : Vector β n) :
     (Vector.zipWith a b f).toArray = Array.zipWith a.toArray b.toArray f := rfl
 
+theorem isEqv_eq_toArray_isEqv_toArray (a b : Vector α n) : a.isEqv b r = a.toArray.isEqv b.toArray r :=
+  match a, b with | ⟨_,_⟩, ⟨_,_⟩ => mk_isEqv_mk ..
+
+theorem beq_eq_toArray_beq [BEq α] (a b : Vector α n) : (a == b) = (a.toArray == b.toArray) := by
+  simp [(· == ·), isEqv_eq_toArray_isEqv_toArray]
+
 /-! ### toList lemmas -/
 
 theorem length_toList {α n} (xs : Vector α n) : xs.toList.length = n := by simp
@@ -293,13 +299,7 @@ instance instDecidableExistsVectorSucc (P : Vector α (n+1) → Prop)
   decidable_of_iff (¬ ∀ v, ¬ P v) Classical.not_forall_not
 
 instance (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
-  rfl {a} := by
-    simp only [(· == ·)]
-    rw [mk_isEqv_mk, Array.isEqv_self_beq]
-  eq_of_beq {a b} := by
-    simp only [(· == ·)]
-    rw [mk_isEqv_mk]
-    intro heqv
-    ext
-    have := Array.rel_of_isEqv heqv
-    simp_all
+  rfl {a} := by simp_all [beq_eq_toArray_beq]
+  eq_of_beq {a b h} := by
+    apply toArray_injective
+    simp_all [beq_eq_toArray_beq]

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -294,7 +294,7 @@ instance instDecidableExistsVectorSucc (P : Vector α (n+1) → Prop)
 
 instance LawfulBEq (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
   rfl {a} := by
-    simp [(· == ·)]
+    simp only [(· == ·)]
     rw [mk_isEqv_mk, Array.isEqv_self_beq]
   eq_of_beq {a b} := by
     simp only [(· == ·)]

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -203,7 +203,8 @@ theorem toArray_mk (a : Array α) (h : a.size = n) : (Vector.mk a h).toArray = a
 @[simp] theorem toArray_zipWith (f : α → β → γ) (a : Vector α n) (b : Vector β n) :
     (Vector.zipWith a b f).toArray = Array.zipWith a.toArray b.toArray f := rfl
 
-theorem isEqv_eq_toArray_isEqv_toArray (a b : Vector α n) : a.isEqv b r = a.toArray.isEqv b.toArray r :=
+theorem isEqv_eq_toArray_isEqv_toArray (a b : Vector α n) :
+    a.isEqv b r = a.toArray.isEqv b.toArray r :=
   match a, b with | ⟨_,_⟩, ⟨_,_⟩ => mk_isEqv_mk ..
 
 theorem beq_eq_toArray_beq [BEq α] (a b : Vector α n) : (a == b) = (a.toArray == b.toArray) := by

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -301,5 +301,5 @@ instance (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
     rw [mk_isEqv_mk]
     intro heqv
     ext
-    have ⟨_, _⟩ := Array.rel_of_isEqv heqv
+    have := Array.rel_of_isEqv heqv
     simp_all

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -300,7 +300,6 @@ instance LawfulBEq (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) wher
     simp only [(· == ·)]
     rw [mk_isEqv_mk]
     intro heqv
-    apply Vector.ext
+    ext
     have ⟨_, h⟩ := Array.rel_of_isEqv heqv
-    simp only [size_toArray, getElem_toArray, beq_iff_eq] at h
-    assumption
+    simp_all

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -301,5 +301,5 @@ instance (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
     rw [mk_isEqv_mk]
     intro heqv
     ext
-    have ⟨_, h⟩ := Array.rel_of_isEqv heqv
+    have ⟨_, _⟩ := Array.rel_of_isEqv heqv
     simp_all

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -293,11 +293,14 @@ instance instDecidableExistsVectorSucc (P : Vector α (n+1) → Prop)
   decidable_of_iff (¬ ∀ v, ¬ P v) Classical.not_forall_not
 
 instance LawfulBEq (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
-  rfl := by simp [(· == ·), isEqv, Array.isEqvAux_self]
+  rfl {a} := by
+    simp [(· == ·)]
+    rw [mk_isEqv_mk, Array.isEqv_self_beq]
   eq_of_beq {a b} := by
-    simp only [(· == ·), isEqv]
+    simp only [(· == ·)]
+    rw [mk_isEqv_mk]
     intro heqv
-    have h := @Array.rel_of_isEqvAux _ (· == ·) _ _ _ n _ heqv
-    simp only [beq_iff_eq, Bool.true_beq, getElem_toArray, eq_of_beq] at h
     apply Vector.ext
+    have ⟨_, h⟩ := Array.rel_of_isEqv heqv
+    simp only [size_toArray, getElem_toArray, beq_iff_eq] at h
     assumption

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -291,3 +291,13 @@ instance instDecidableExistsVectorZero (P : Vector α 0 → Prop) [Decidable (P 
 instance instDecidableExistsVectorSucc (P : Vector α (n+1) → Prop)
     [Decidable (∀ (x : α) (v : Vector α n), ¬ P (v.push x))] : Decidable (∃ v, P v) :=
   decidable_of_iff (¬ ∀ v, ¬ P v) Classical.not_forall_not
+
+instance LawfulBEq (α n) [BEq α] [LawfulBEq α] : LawfulBEq (Vector α n) where
+  rfl := by simp [(· == ·), isEqv, Array.isEqvAux_self]
+  eq_of_beq {a b} := by
+    simp only [(· == ·), isEqv]
+    intro heqv
+    have h := @Array.rel_of_isEqvAux _ (· == ·) _ _ _ n _ heqv
+    simp only [beq_iff_eq, Bool.true_beq, getElem_toArray, eq_of_beq] at h
+    apply Vector.ext
+    assumption


### PR DESCRIPTION
The `eq_of_beq` proof is a bit hairy, and I couldn't find a proof that didn't use `Vector.ext`, so I moved the instance to be with the other `Vector` lemmas. All review is greatly appreciated.