### PR TITLE
chore: remove meta results for README `proof_wanted` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _nothing else_.
 This will remove the previous label and replace it by the requested status label.
 
 One of the easiest ways to contribute is to find a missing proof and complete it. The
-[`proof_wanted`](https://github.com/search?q=repo%3Aleanprover-community%2Fbatteries+proof_wanted+language%3ALean&type=code&l=Lean)
+[`proof_wanted`](https://github.com/search?q=repo%3Aleanprover-community%2Fbatteries+proof_wanted+language%3ALean+NOT+path%3A%2Fproof_%3Fwanted%2F&type=code)
 declaration documents statements that have been identified as being useful, but that have not yet
 been proven.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ _nothing else_.
 This will remove the previous label and replace it by the requested status label.
 
 One of the easiest ways to contribute is to find a missing proof and complete it. The
-[`proof_wanted`](https://github.com/search?q=repo%3Aleanprover-community%2Fbatteries+proof_wanted+language%3ALean+NOT+path%3A%2Fproof_%3Fwanted%2F&type=code)
+[`proof_wanted`](https://github.com/search?q=repo%3Aleanprover-community%2Fbatteries+language%3ALean+%2F^proof_wanted%2F&type=code)
 declaration documents statements that have been identified as being useful, but that have not yet
 been proven.
 


### PR DESCRIPTION
Currently, the [`proof_wanted`](https://github.com/search?q=repo%3Aleanprover-community%2Fbatteries+proof_wanted+language%3ALean&type=code&l=Lean) link brings up two results relating to the implementation and testing of `proof_wanted`. Adding `NOT path:/proof_?wanted/` prevents this, making the link marginally more useful.