### PR TITLE
fix: use ext attribute to generate ext lemmas for `ByteArray` and `FloatArray`

### DIFF
--- a/Batteries/Data/ByteArray.lean
+++ b/Batteries/Data/ByteArray.lean
@@ -7,8 +7,10 @@ import Batteries.Tactic.Alias
 
 namespace ByteArray
 
-@[ext] theorem ext : {a b : ByteArray} → a.data = b.data → a = b
-  | ⟨_⟩, ⟨_⟩, rfl => rfl
+attribute [ext] ByteArray
+
+instance : DecidableEq ByteArray :=
+  fun _ _ => decidable_of_decidable_of_iff ByteArray.ext_iff.symm
 
 theorem getElem_eq_data_getElem (a : ByteArray) (h : i < a.size) : a[i] = a.data[i] := rfl
 

--- a/Batteries/Data/FloatArray.lean
+++ b/Batteries/Data/FloatArray.lean
@@ -6,6 +6,8 @@ Authors: François G. Dorais
 
 namespace FloatArray
 
+attribute [ext] FloatArray
+
 /--
 Unsafe optimized implementation of `mapM`.
 


### PR DESCRIPTION
Also adds a decidable equality instance for `ByteArray`.