### PR TITLE
chore: fix labels-from-status

### DIFF
--- a/.github/workflows/labels-from-status.yml
+++ b/.github/workflows/labels-from-status.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - opened


### PR DESCRIPTION
Always run on target branch instead of the PR branch to have permission to write labels.