### PR TITLE
feat: add `LawfulMonadLift`

### DIFF
--- a/Batteries.lean
+++ b/Batteries.lean
@@ -10,6 +10,7 @@ import Batteries.CodeAction.Misc
 import Batteries.Control.ForInStep
 import Batteries.Control.ForInStep.Basic
 import Batteries.Control.ForInStep.Lemmas
+import Batteries.Control.Lawful.MonadLift
 import Batteries.Control.Lemmas
 import Batteries.Control.Monad
 import Batteries.Control.Nondet.Basic

--- a/Batteries.lean
+++ b/Batteries.lean
@@ -51,6 +51,7 @@ import Batteries.Lean.HashSet
 import Batteries.Lean.IO.Process
 import Batteries.Lean.Json
 import Batteries.Lean.LawfulMonad
+import Batteries.Lean.LawfulMonadLift
 import Batteries.Lean.Meta.Basic
 import Batteries.Lean.Meta.DiscrTree
 import Batteries.Lean.Meta.Expr

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -12,7 +12,8 @@ This file defines the `LawfulMonadLift(T)` class, which adds laws to the `MonadL
 
 universe u v w
 
-/-- The `MonadLift` typeclass only contains the lifting operation. `LawfulMonadLift` further asserts that lifting commutes with `pure` and `bind`:
+/-- The `MonadLift` typeclass only contains the lifting operation. `LawfulMonadLift` further
+  asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
 monadLift ma >>= (monadLift ∘ f) = monadLift (ma >>= f)

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -56,28 +56,26 @@ theorem liftM_bind {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Mo
   monadLift_bind _ _
 
 instance (m n o) [Monad m] [Monad n] [Monad o] [MonadLift n o] [MonadLiftT m n]
-    [LawfulMonad m] [LawfulMonad n] [LawfulMonad o] [LawfulMonadLift n o] [LawfulMonadLiftT m n] : LawfulMonadLiftT m o where
+    [LawfulMonadLift n o] [LawfulMonadLiftT m n] : LawfulMonadLiftT m o where
   monadLift_pure := fun a => by
     simp only [monadLift, LawfulMonadLift.monadLift_pure, liftM_pure]
   monadLift_bind := fun ma f => by
     simp only [monadLift, LawfulMonadLift.monadLift_bind, liftM_bind]
 
-instance (m) [Monad m] [LawfulMonad m] : LawfulMonadLiftT m m where
+instance (m) [Monad m] : LawfulMonadLiftT m m where
   monadLift_pure _ := rfl
   monadLift_bind _ _ := rfl
 
 namespace StateT
 
-variable {σ : Type u} {m : Type u → Type v} [Monad m] [LawfulMonad m]
+variable {σ} [Monad m] [LawfulMonad m]
 
 instance : LawfulMonadLift m (StateT σ m) where
-  monadLift_pure := by
-    intro α a
+  monadLift_pure _ := by
     simp only [MonadLift.monadLift]
     unfold StateT.lift StateT.instMonad StateT.bind StateT.pure
     simp only [bind_pure_comp, map_pure]
-  monadLift_bind := by
-    intro α β ma f
+  monadLift_bind _ _ := by
     simp only [MonadLift.monadLift]
     unfold StateT.lift StateT.instMonad StateT.bind StateT.pure
     simp only [bind_pure_comp, Function.comp_apply, bind_map_left, map_bind]
@@ -86,15 +84,13 @@ end StateT
 
 namespace ReaderT
 
-variable {ρ : Type u} {m : Type u → Type v} [Monad m]
+variable {ρ} [Monad m]
 
 instance : LawfulMonadLift m (ReaderT ρ m) where
-  monadLift_pure := by
-    intro α a
+  monadLift_pure _ := by
     funext x
     simp only [MonadLift.monadLift, pure, ReaderT.pure]
-  monadLift_bind := by
-    intro α β ma f
+  monadLift_bind _ _ := by
     funext x
     simp only [bind, ReaderT.bind, MonadLift.monadLift, Function.comp_apply]
 
@@ -102,7 +98,7 @@ end ReaderT
 
 namespace OptionT
 
-variable {m : Type u → Type v} [Monad m] [LawfulMonad m]
+variable [Monad m] [LawfulMonad m]
 
 @[simp]
 theorem lift_pure {α : Type u} (a : α) : OptionT.lift (pure a : m α) = pure a := by
@@ -122,10 +118,10 @@ end OptionT
 
 namespace ExceptT
 
-variable {ε : Type u} {m : Type u → Type v} [Monad m] [LawfulMonad m]
+variable {ε} [Monad m] [LawfulMonad m]
 
 @[simp]
-theorem lift_bind {α β : Type u} (ma : m α) (f : α → m β) :
+theorem lift_bind {α β} (ma : m α) (f : α → m β) :
     ExceptT.lift ma >>= (fun a => ExceptT.lift (f a)) = ExceptT.lift (ε := ε) (ma >>= f) := by
   simp only [instMonad, ExceptT.bind, mk, ExceptT.lift, bind_map_left, ExceptT.bindCont, map_bind]
 
@@ -134,13 +130,83 @@ instance : LawfulMonadLift m (ExceptT ε m) where
   monadLift_bind := lift_bind
 
 instance : LawfulMonadLift (Except ε) (ExceptT ε m) where
-  monadLift_pure := by
-    intro α a
+  monadLift_pure _ := by
     simp only [MonadLift.monadLift, mk, pure, Except.pure, ExceptT.pure]
-  monadLift_bind := by
-    intro α β ma f
+  monadLift_bind ma _ := by
     simp only [instMonad, ExceptT.bind, mk, MonadLift.monadLift, pure_bind, ExceptT.bindCont,
       Except.instMonad, Except.bind]
     rcases ma with _ | _ <;> simp
 
 end ExceptT
+
+namespace StateRefT'
+
+instance {ω σ m} [Monad m] : LawfulMonadLift m (StateRefT' ω σ m) where
+  monadLift_pure _ := by
+    simp only [MonadLift.monadLift, pure]
+    unfold StateRefT'.lift ReaderT.pure
+    simp only
+  monadLift_bind _ _ := by
+    simp only [MonadLift.monadLift, bind]
+    unfold StateRefT'.lift ReaderT.bind
+    simp only
+
+end StateRefT'
+
+namespace StateCpsT
+
+instance {σ m} [Monad m] [LawfulMonad m] : LawfulMonadLift m (StateCpsT σ m) where
+  monadLift_pure _ := by
+    simp only [MonadLift.monadLift, pure]
+    unfold StateCpsT.lift
+    simp only [pure_bind]
+  monadLift_bind _ _ := by
+    simp only [MonadLift.monadLift, bind]
+    unfold StateCpsT.lift
+    simp only [bind_assoc]
+
+end StateCpsT
+
+namespace ExceptCpsT
+
+instance {ε m} [Monad m] [LawfulMonad m] : LawfulMonadLift m (ExceptCpsT ε m) where
+  monadLift_pure _ := by
+    simp [MonadLift.monadLift, pure]
+    unfold ExceptCpsT.lift
+    simp only [pure_bind]
+  monadLift_bind _ _ := by
+    simp only [MonadLift.monadLift, bind]
+    unfold ExceptCpsT.lift
+    simp only [bind_assoc]
+
+end ExceptCpsT
+
+instance {ε} : LawfulMonadLift BaseIO (EIO ε) where
+  monadLift_pure _ := by
+    simp only [MonadLift.monadLift, pure]
+    unfold BaseIO.toEIO EStateM.pure
+    simp only
+  monadLift_bind ma f := by
+    simp only [MonadLift.monadLift, bind]
+    unfold BaseIO.toEIO EStateM.bind IO.RealWorld
+    funext x
+    simp only
+    rcases ma x with a | a
+    · simp only
+    · contradiction
+
+instance {ε σ} : LawfulMonadLift (ST σ) (EST ε σ) where
+  monadLift_pure a := by
+    simp [MonadLift.monadLift, pure]
+    funext x
+    rcases h : EStateM.pure a x with y | y
+    · simp_all only [EStateM.pure, EStateM.Result.ok.injEq]
+    · contradiction
+  monadLift_bind ma f := by
+    simp only [MonadLift.monadLift, bind]
+    unfold EStateM.bind
+    funext x
+    simp
+    rcases ma x with a | a
+    · simp
+    · contradiction

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -1,0 +1,145 @@
+/-
+Copyright (c) 2025 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+/-!
+# Lawful version of `MonadLift`
+
+This file defines the `LawfulMonadLift(T)` class, which adds laws to the `MonadLift(T)` class.
+-/
+
+universe u v w
+
+/-- The `MonadLift` typeclass only contains the lifting operation. `LawfulMonadLift` further asserts that lifting commutes with `pure` and `bind`:
+```
+monadLift (pure a) = pure a
+monadLift ma >>= (monadLift ∘ f) = monadLift (ma >>= f)
+```
+-/
+class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Type w)
+    [Monad m] [Monad n] [MonadLift m n] : Prop where
+
+  /-- Lifting preserves `pure` -/
+  monadLift_pure {α : Type u} (a : α) : @MonadLift.monadLift m n _ _ (pure a) = pure a
+
+  /-- Lifting preserves `bind` -/
+  monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
+    MonadLift.monadLift ma >>= (fun a => MonadLift.monadLift (f a)) =
+      MonadLift.monadLift (n := n) (ma >>= f)
+
+/-- The `MonadLiftT` typeclass only contains the transitive lifting operation. `LawfulMonadLiftT` further asserts that lifting commutes with `pure` and `bind`:
+```
+monadLift (pure a) = pure a
+monadLift ma >>= (monadLift ∘ f) = monadLift (ma >>= f)
+```
+-/
+class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m] [Monad n]
+    [MonadLiftT m n] : Prop where
+
+  /-- Lifting preserves `pure` -/
+  monadLift_pure {α : Type u} (a : α) : @monadLift m n _ _ (pure a) = pure a
+
+  /-- Lifting preserves `bind` -/
+  monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
+    monadLift ma >>= (fun a => monadLift (f a)) = monadLift (n := n) (ma >>= f)
+
+export LawfulMonadLiftT (monadLift_pure monadLift_bind)
+
+attribute [simp] monadLift_pure monadLift_bind
+
+@[simp]
+theorem liftM_pure {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n] [MonadLiftT m n]
+    [LawfulMonadLiftT m n] {α : Type u} (a : α) : liftM (pure a : m α) = pure (f := n) a :=
+  monadLift_pure _
+
+@[simp]
+theorem liftM_bind {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n] [MonadLiftT m n]
+    [LawfulMonadLiftT m n] {α β : Type u} (ma : m α) (f : α → m β) :
+      liftM ma >>= (fun a => liftM (f a)) = liftM (n := n) (ma >>= f) :=
+  monadLift_bind _ _
+
+instance {m : semiOutParam (Type u → Type v)} {n : Type u → Type w} [Monad m] [Monad n]
+    [MonadLift m n] [LawfulMonadLift m n] : LawfulMonadLiftT m n where
+  monadLift_pure := LawfulMonadLift.monadLift_pure
+  monadLift_bind := LawfulMonadLift.monadLift_bind
+
+namespace StateT
+
+variable {σ : Type u} {m : Type u → Type v} [Monad m] [LawfulMonad m]
+
+instance : LawfulMonadLift m (StateT σ m) where
+  monadLift_pure := by
+    intro α a
+    simp only [MonadLift.monadLift]
+    unfold StateT.lift StateT.instMonad StateT.bind StateT.pure
+    simp only [bind_pure_comp, map_pure]
+  monadLift_bind := by
+    intro α β ma f
+    simp only [MonadLift.monadLift]
+    unfold StateT.lift StateT.instMonad StateT.bind StateT.pure
+    simp only [bind_pure_comp, Function.comp_apply, bind_map_left, map_bind]
+
+end StateT
+
+namespace ReaderT
+
+variable {ρ : Type u} {m : Type u → Type v} [Monad m]
+
+instance : LawfulMonadLift m (ReaderT ρ m) where
+  monadLift_pure := by
+    intro α a
+    funext x
+    simp only [MonadLift.monadLift, pure, ReaderT.pure]
+  monadLift_bind := by
+    intro α β ma f
+    funext x
+    simp only [MonadLift.monadLift, bind, ReaderT.bind]
+
+end ReaderT
+
+namespace OptionT
+
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m]
+
+@[simp]
+theorem lift_pure {α : Type u} (a : α) : OptionT.lift (pure a : m α) = pure a := by
+  simp only [OptionT.lift, OptionT.mk, bind_pure_comp, map_pure, pure, OptionT.pure]
+
+@[simp]
+theorem lift_bind {α β : Type u} (ma : m α) (f : α → m β) :
+    OptionT.lift ma >>= (fun a => OptionT.lift (f a)) = OptionT.lift (ma >>= f) := by
+  simp only [instMonad, OptionT.bind, OptionT.mk, OptionT.lift, bind_pure_comp, bind_map_left,
+    map_bind]
+
+instance : LawfulMonadLift m (OptionT m) where
+  monadLift_pure := lift_pure
+  monadLift_bind := lift_bind
+
+end OptionT
+
+namespace ExceptT
+
+variable {ε : Type u} {m : Type u → Type v} [Monad m] [LawfulMonad m]
+
+@[simp]
+theorem lift_bind {α β : Type u} (ma : m α) (f : α → m β) :
+    ExceptT.lift ma >>= (fun a => ExceptT.lift (f a)) = ExceptT.lift (ε := ε) (ma >>= f) := by
+  simp only [instMonad, ExceptT.bind, mk, ExceptT.lift, bind_map_left, ExceptT.bindCont, map_bind]
+
+instance : LawfulMonadLift m (ExceptT ε m) where
+  monadLift_pure := lift_pure
+  monadLift_bind := lift_bind
+
+instance : LawfulMonadLift (Except ε) (ExceptT ε m) where
+  monadLift_pure := by
+    intro α a
+    simp only [MonadLift.monadLift, mk, pure, Except.pure, ExceptT.pure]
+  monadLift_bind := by
+    intro α β ma f
+    simp only [instMonad, ExceptT.bind, mk, MonadLift.monadLift, pure_bind, ExceptT.bindCont,
+      Except.instMonad, Except.bind]
+    rcases ma with _ | _ <;> simp
+
+end ExceptT

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -49,8 +49,6 @@ class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m]
 
 export LawfulMonadLiftT (monadLift_pure monadLift_bind)
 
-attribute [simp] monadLift_pure monadLift_bind
-
 @[simp]
 theorem liftM_pure {m : Type u → Type v} {n : Type u → Type w} [Monad m] [Monad n] [MonadLiftT m n]
     [LawfulMonadLiftT m n] {α : Type u} (a : α) : liftM (pure a : m α) = pure (f := n) a :=

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -30,7 +30,8 @@ class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Typ
     MonadLift.monadLift ma >>= (fun a => MonadLift.monadLift (f a)) =
       MonadLift.monadLift (n := n) (ma >>= f)
 
-/-- The `MonadLiftT` typeclass only contains the transitive lifting operation. `LawfulMonadLiftT` further asserts that lifting commutes with `pure` and `bind`:
+/-- The `MonadLiftT` typeclass only contains the transitive lifting operation.
+  `LawfulMonadLiftT` further asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
 monadLift ma >>= (monadLift ∘ f) = monadLift (ma >>= f)

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -16,7 +16,7 @@ universe u v w
   asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
-monadLift ma >>= (monadLift ∘ f) = monadLift (ma >>= f)
+monadLift ma >>= monadLift ∘ f = monadLift (ma >>= f)
 ```
 -/
 class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Type w)
@@ -27,14 +27,14 @@ class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Typ
 
   /-- Lifting preserves `bind` -/
   monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
-    MonadLift.monadLift ma >>= (fun a => MonadLift.monadLift (f a)) =
+    MonadLift.monadLift ma >>= MonadLift.monadLift ∘ f =
       MonadLift.monadLift (n := n) (ma >>= f)
 
 /-- The `MonadLiftT` typeclass only contains the transitive lifting operation.
   `LawfulMonadLiftT` further asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
-monadLift ma >>= (monadLift ∘ f) = monadLift (ma >>= f)
+monadLift ma >>= monadLift ∘ f = monadLift (ma >>= f)
 ```
 -/
 class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m] [Monad n]
@@ -45,7 +45,7 @@ class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m]
 
   /-- Lifting preserves `bind` -/
   monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
-    monadLift ma >>= (fun a => monadLift (f a)) = monadLift (n := n) (ma >>= f)
+    monadLift ma >>= monadLift ∘ f = monadLift (n := n) (ma >>= f)
 
 export LawfulMonadLiftT (monadLift_pure monadLift_bind)
 
@@ -97,7 +97,7 @@ instance : LawfulMonadLift m (ReaderT ρ m) where
   monadLift_bind := by
     intro α β ma f
     funext x
-    simp only [MonadLift.monadLift, bind, ReaderT.bind]
+    simp only [bind, ReaderT.bind, MonadLift.monadLift, Function.comp_apply]
 
 end ReaderT
 

--- a/Batteries/Lean/LawfulMonadLift.lean
+++ b/Batteries/Lean/LawfulMonadLift.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2025 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import Batteries.Control.Lawful.MonadLift
+import Batteries.Lean.LawfulMonad
+
+/-!
+# Lawful instances of `MonadLift` for the Lean monad stack.
+-/
+
+open Lean Elab Term Tactic Command
+
+instance : LawfulMonadLift BaseIO (EIO ε) where
+  monadLift_pure _ := rfl
+  monadLift_bind ma f := by
+    simp only [MonadLift.monadLift, bind]
+    unfold BaseIO.toEIO EStateM.bind IO.RealWorld
+    simp only
+    funext x
+    rcases ma x with a | a
+    · simp only
+    · contradiction
+
+instance : LawfulMonadLift (ST σ) (EST ε σ) where
+  monadLift_pure a := rfl
+  monadLift_bind ma f := by
+    simp only [MonadLift.monadLift, bind]
+    unfold EStateM.bind
+    simp only
+    funext x
+    rcases ma x with a | a
+    · simp only
+    · contradiction
+
+instance : LawfulMonadLift IO CoreM where
+  monadLift_pure _ := rfl
+  -- TODO: introduce helper lemmas instead of unfolding everything
+  monadLift_bind ma f := by
+    simp only [MonadLift.monadLift, bind, pure, Core.liftIOCore, liftM, monadLift, getRef, read,
+      readThe, MonadReaderOf.read, IO.toEIO]
+    unfold StateRefT'.lift ReaderT.read ReaderT.bind ReaderT.pure
+    simp only [pure_bind, Function.comp_apply, bind_assoc, bind, pure]
+    unfold ReaderT.bind ReaderT.pure
+    simp only [bind_pure_comp, map_pure, pure_bind, bind, pure]
+    unfold EStateM.adaptExcept EStateM.bind EStateM.pure
+    simp only
+    funext _ _ s
+    rcases ma s with a | a <;> simp only
+
+instance : LawfulMonadLiftT (EIO Exception) CommandElabM := inferInstance
+instance : LawfulMonadLiftT (EIO Exception) CoreM := inferInstance
+instance : LawfulMonadLiftT CoreM MetaM := inferInstance
+instance : LawfulMonadLiftT MetaM TermElabM := inferInstance
+instance : LawfulMonadLiftT TermElabM TacticM := inferInstance

--- a/Batteries/Lean/LawfulMonadLift.lean
+++ b/Batteries/Lean/LawfulMonadLift.lean
@@ -36,7 +36,6 @@ instance : LawfulMonadLift (ST σ) (EST ε σ) where
 
 instance : LawfulMonadLift IO CoreM where
   monadLift_pure _ := rfl
-  -- TODO: introduce helper lemmas instead of unfolding everything
   monadLift_bind ma f := by
     simp only [MonadLift.monadLift, bind, pure, Core.liftIOCore, liftM, monadLift, getRef, read,
       readThe, MonadReaderOf.read, IO.toEIO]


### PR DESCRIPTION
This PR adds `LawfulMonadLift` and `LawfulMonadLiftT` type classes to add laws to the existing `MonadLift(T)` type class, which only contains the lifting operation. We also derive `Lawful` instances for common liftings.

One thing to note: I'm not sure how the `simp` direction should go in `monadLift_bind`, and whether we should have `simp` for both specific version (`ExceptT.lift_bind`) and generic version.

If this PR goes well, I will add more `Lawful` type classes to `Monad{Functor/Control/State/Option/etc}`.