### PR TITLE
chore: fix simp direction for `monadLift_bind`

### DIFF
--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -44,8 +44,6 @@ class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m]
 
 export LawfulMonadLiftT (monadLift_pure monadLift_bind)
 
-variable {m : Type u → Type v} {n : Type u → Type w} {α β σ ρ ε ω}
-
 section Lemmas
 
 variable [Monad m] [Monad n] [MonadLiftT m n] [LawfulMonadLiftT m n]
@@ -98,6 +96,8 @@ theorem liftM_seqRight [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
     liftM (x *> y) = (liftM x : n α) *> (liftM y : n β) :=
   monadLift_seqRight _ _
 
+end Lemmas
+
 instance (m n o) [Monad m] [Monad n] [Monad o] [MonadLift n o] [MonadLiftT m n]
     [LawfulMonadLift n o] [LawfulMonadLiftT m n] : LawfulMonadLiftT m o where
   monadLift_pure := fun a => by
@@ -108,8 +108,6 @@ instance (m n o) [Monad m] [Monad n] [Monad o] [MonadLift n o] [MonadLiftT m n]
 instance (m) [Monad m] : LawfulMonadLiftT m m where
   monadLift_pure _ := rfl
   monadLift_bind _ _ := rfl
-
-end Lemmas
 
 namespace StateT
 
@@ -186,7 +184,7 @@ end ExceptT
 
 namespace StateRefT'
 
-instance {m} [Monad m] : LawfulMonadLift m (StateRefT' ω σ m) where
+instance [Monad m] : LawfulMonadLift m (StateRefT' ω σ m) where
   monadLift_pure _ := by
     simp only [MonadLift.monadLift, pure]
     unfold StateRefT'.lift ReaderT.pure
@@ -227,8 +225,6 @@ instance [Monad m] [LawfulMonad m] : LawfulMonadLift m (ExceptCpsT ε m) where
 end ExceptCpsT
 
 namespace Id
-
-variable {m : Type u → Type v}
 
 /-- The `pure` operation of a monad `m` can be seen as a lifting operation from `Id` to `m`. -/
 instance [Pure m] : MonadLift Id m where

--- a/Batteries/Control/Lawful/MonadLift.lean
+++ b/Batteries/Control/Lawful/MonadLift.lean
@@ -16,7 +16,7 @@ universe u v w
   asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
-monadLift ma >>= monadLift ∘ f = monadLift (ma >>= f)
+monadLift (ma >>= f) = monadLift ma >>= monadLift ∘ f
 ```
 -/
 class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Type w)
@@ -25,13 +25,13 @@ class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Typ
   monadLift_pure {α : Type u} (a : α) : inst.monadLift (pure a) = pure a
   /-- Lifting preserves `bind` -/
   monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
-    inst.monadLift ma >>= (fun x => inst.monadLift (f x)) = inst.monadLift (ma >>= f)
+    inst.monadLift (ma >>= f) = inst.monadLift ma >>= (fun x => inst.monadLift (f x))
 
 /-- The `MonadLiftT` typeclass only contains the transitive lifting operation.
   `LawfulMonadLiftT` further asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
-monadLift ma >>= monadLift ∘ f = monadLift (ma >>= f)
+monadLift (ma >>= f) = monadLift ma >>= monadLift ∘ f
 ```
 -/
 class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m] [Monad n]
@@ -40,13 +40,34 @@ class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m]
   monadLift_pure {α : Type u} (a : α) : inst.monadLift (pure a) = pure a
   /-- Lifting preserves `bind` -/
   monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
-    monadLift ma >>= (fun x => monadLift (f x)) = inst.monadLift (ma >>= f)
+    inst.monadLift (ma >>= f) = monadLift ma >>= (fun x => monadLift (f x))
 
 export LawfulMonadLiftT (monadLift_pure monadLift_bind)
+
+variable {m : Type u → Type v} {n : Type u → Type w} {α β σ ρ ε ω}
 
 section Lemmas
 
 variable [Monad m] [Monad n] [MonadLiftT m n] [LawfulMonadLiftT m n]
+
+theorem monadLift_map [LawfulMonad m] [LawfulMonad n] (f : α → β) (ma : m α) :
+    monadLift (f <$> ma) = f <$> (monadLift ma : n α) := by
+  rw [← bind_pure_comp, ← bind_pure_comp, monadLift_bind]
+  simp only [bind_pure_comp, monadLift_pure]
+
+theorem monadLift_seq [LawfulMonad m] [LawfulMonad n] (mf : m (α → β)) (ma : m α) :
+    monadLift (mf <*> ma) = monadLift mf <*> (monadLift ma : n α) := by
+  simp only [seq_eq_bind, monadLift_map, monadLift_bind]
+
+theorem monadLift_seqLeft [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
+    monadLift (x <* y) = (monadLift x : n α) <* (monadLift y : n β) := by
+  simp only [seqLeft_eq, monadLift_map, monadLift_seq]
+
+theorem monadLift_seqRight [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
+    monadLift (x *> y) = (monadLift x : n α) *> (monadLift y : n β) := by
+  simp only [seqRight_eq, monadLift_map, monadLift_seq]
+
+/-! We duplicate the theorems for `monadLift` to `liftM` since `rw` matches on syntax only. -/
 
 @[simp]
 theorem liftM_pure (a : α) : liftM (pure a : m α) = pure (f := n) a :=
@@ -54,31 +75,28 @@ theorem liftM_pure (a : α) : liftM (pure a : m α) = pure (f := n) a :=
 
 @[simp]
 theorem liftM_bind (ma : m α) (f : α → m β) :
-    liftM ma >>= (fun a => liftM (f a)) = liftM (n := n) (ma >>= f) :=
+    liftM (n := n) (ma >>= f) = liftM ma >>= (fun a => liftM (f a)) :=
   monadLift_bind _ _
 
 @[simp]
 theorem liftM_map [LawfulMonad m] [LawfulMonad n] (f : α → β) (ma : m α) :
-    f <$> (liftM ma : n α) = liftM (f <$> ma) := by
-  rw [← bind_pure_comp, ← bind_pure_comp, ← liftM_bind]
-  simp only [bind_pure_comp, liftM_pure]
+    liftM (f <$> ma) = f <$> (liftM ma : n α) :=
+  monadLift_map _ _
 
 @[simp]
 theorem liftM_seq [LawfulMonad m] [LawfulMonad n] (mf : m (α → β)) (ma : m α) :
-    liftM mf <*> (liftM ma : n α) = liftM (mf <*> ma) := by
-  simp only [seq_eq_bind, liftM_map, liftM_bind]
+    liftM (mf <*> ma) = liftM mf <*> (liftM ma : n α) :=
+  monadLift_seq _ _
 
 @[simp]
 theorem liftM_seqLeft [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
-    (liftM x : n α) <* (liftM y : n β) = liftM (x <* y) := by
-  simp only [seqLeft_eq, liftM_map, liftM_seq]
+    liftM (x <* y) = (liftM x : n α) <* (liftM y : n β) :=
+  monadLift_seqLeft _ _
 
 @[simp]
 theorem liftM_seqRight [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
-    (liftM x : n α) *> (liftM y : n β) = liftM (x *> y) := by
-  simp only [seqRight_eq, liftM_map, liftM_seq]
-
-end Lemmas
+    liftM (x *> y) = (liftM x : n α) *> (liftM y : n β) :=
+  monadLift_seqRight _ _
 
 instance (m n o) [Monad m] [Monad n] [Monad o] [MonadLift n o] [MonadLiftT m n]
     [LawfulMonadLift n o] [LawfulMonadLiftT m n] : LawfulMonadLiftT m o where
@@ -90,6 +108,8 @@ instance (m n o) [Monad m] [Monad n] [Monad o] [MonadLift n o] [MonadLiftT m n]
 instance (m) [Monad m] : LawfulMonadLiftT m m where
   monadLift_pure _ := rfl
   monadLift_bind _ _ := rfl
+
+end Lemmas
 
 namespace StateT
 
@@ -131,7 +151,7 @@ theorem lift_pure (a : α) : OptionT.lift (pure a : m α) = pure a := by
 
 @[simp]
 theorem lift_bind (ma : m α) (f : α → m β) :
-    OptionT.lift ma >>= (fun a => OptionT.lift (f a)) = OptionT.lift (ma >>= f) := by
+    OptionT.lift (ma >>= f) = OptionT.lift ma >>= (fun a => OptionT.lift (f a)) := by
   simp only [instMonad, OptionT.bind, OptionT.mk, OptionT.lift, bind_pure_comp, bind_map_left,
     map_bind]
 
@@ -147,7 +167,7 @@ variable [Monad m] [LawfulMonad m]
 
 @[simp]
 theorem lift_bind (ma : m α) (f : α → m β) :
-    ExceptT.lift ma >>= (fun a => ExceptT.lift (f a)) = ExceptT.lift (ε := ε) (ma >>= f) := by
+    ExceptT.lift (ε := ε) (ma >>= f) = ExceptT.lift ma >>= (fun a => ExceptT.lift (f a)) := by
   simp only [instMonad, ExceptT.bind, mk, ExceptT.lift, bind_map_left, ExceptT.bindCont, map_bind]
 
 instance : LawfulMonadLift m (ExceptT ε m) where
@@ -166,7 +186,7 @@ end ExceptT
 
 namespace StateRefT'
 
-instance [Monad m] : LawfulMonadLift m (StateRefT' ω σ m) where
+instance {m} [Monad m] : LawfulMonadLift m (StateRefT' ω σ m) where
   monadLift_pure _ := by
     simp only [MonadLift.monadLift, pure]
     unfold StateRefT'.lift ReaderT.pure
@@ -196,7 +216,7 @@ namespace ExceptCpsT
 
 instance [Monad m] [LawfulMonad m] : LawfulMonadLift m (ExceptCpsT ε m) where
   monadLift_pure _ := by
-    simp [MonadLift.monadLift, pure]
+    simp only [MonadLift.monadLift, pure]
     unfold ExceptCpsT.lift
     simp only [pure_bind]
   monadLift_bind _ _ := by
@@ -205,3 +225,18 @@ instance [Monad m] [LawfulMonad m] : LawfulMonadLift m (ExceptCpsT ε m) where
     simp only [bind_assoc]
 
 end ExceptCpsT
+
+namespace Id
+
+variable {m : Type u → Type v}
+
+/-- The `pure` operation of a monad `m` can be seen as a lifting operation from `Id` to `m`. -/
+instance [Pure m] : MonadLift Id m where
+  monadLift := pure
+
+/-- The lifting from `Id` to a lawful monad `m` induced by `pure` is lawful. -/
+instance [Monad m] [LawfulMonad m] : LawfulMonadLift Id m where
+  monadLift_pure := fun a => by simp [MonadLift.monadLift, pure]
+  monadLift_bind := fun x f => by simp [MonadLift.monadLift, bind]
+
+end Id


### PR DESCRIPTION
This PR reverses the simp direction of lawful `monadLift` operations, so that they got pulled inward rather than outward. This is similar to the direction in classes like `MulHomClass` and also consistent with the [Haskell documentation](https://hackage.haskell.org/package/transformers-0.5.6.2/docs/Control-Monad-Trans-Class.html#t:MonadTrans).

We also duplicate the lemmas for `monadLift` and `liftM` to help in rewriting, which matches on syntax only. We set the simp attribute for lemmas about `liftM` only, since simp can look into definitions.

Finally, we add the canonical lifting operation from `Id` to any monad `m` via its `pure` function.