### PR TITLE
chore(Logic): give implicit argument an accessible name

### DIFF
--- a/Batteries/Logic.lean
+++ b/Batteries/Logic.lean
@@ -26,7 +26,7 @@ end Classical
 
 /-! ## equality -/
 
-theorem heq_iff_eq : HEq a b ↔ a = b := ⟨eq_of_heq, heq_of_eq⟩
+theorem heq_iff_eq {a b : α} : HEq a b ↔ a = b := ⟨eq_of_heq, heq_of_eq⟩
 
 @[simp] theorem eq_rec_constant {α : Sort _} {a a' : α} {β : Sort _} (y : β) (h : a = a') :
     (@Eq.rec α a (fun _ _ => β) y a' h) = y := by cases h; rfl


### PR DESCRIPTION
Currently, the `Sort u` argument to `heq_iff_eq` has name `α✝`, making it inaccessible using `(_ := _)` syntax. As such, the change here refers to `α` by name so that it has name `α` instead. 

Note that this PR does not change the implicitness of any of the variables. 
This is the smallest change I could think of which would have the desired effect (making the type argument accessible) and change nothing else, but if there is a preferred alternate option, I am happy to go with that instead.