### PR TITLE
chore: generalize `TransCmp` -> `OrientedCmp`

### DIFF
--- a/Batteries/Classes/Order.lean
+++ b/Batteries/Classes/Order.lean
@@ -20,26 +20,24 @@ class OrientedCmp (cmp : α → α → Ordering) : Prop where
 
 namespace OrientedCmp
 
-variable {α} {cmp : α → α → Ordering} [OrientedCmp cmp] {x y : α}
-
-theorem cmp_eq_gt : cmp x y = .gt ↔ cmp y x = .lt := by
+theorem cmp_eq_gt [OrientedCmp cmp] : cmp x y = .gt ↔ cmp y x = .lt := by
   rw [← Ordering.swap_inj, symm]; exact .rfl
 
-theorem cmp_ne_gt : cmp x y ≠ .gt ↔ cmp y x ≠ .lt := not_congr cmp_eq_gt
+theorem cmp_ne_gt [OrientedCmp cmp] : cmp x y ≠ .gt ↔ cmp y x ≠ .lt := not_congr cmp_eq_gt
 
-theorem cmp_eq_eq_symm : cmp x y = .eq ↔ cmp y x = .eq := by
+theorem cmp_eq_eq_symm [OrientedCmp cmp] : cmp x y = .eq ↔ cmp y x = .eq := by
   rw [← Ordering.swap_inj, symm]; exact .rfl
 
-theorem cmp_refl : cmp x x = .eq :=
+theorem cmp_refl [OrientedCmp cmp] : cmp x x = .eq :=
   match e : cmp x x with
   | .lt => nomatch e.symm.trans (cmp_eq_gt.2 e)
   | .eq => rfl
   | .gt => nomatch (cmp_eq_gt.1 e).symm.trans e
 
-theorem lt_asymm (h : cmp x y = .lt) : cmp y x ≠ .lt :=
+theorem lt_asymm [OrientedCmp cmp] (h : cmp x y = .lt) : cmp y x ≠ .lt :=
   fun h' => nomatch h.symm.trans (cmp_eq_gt.2 h')
 
-theorem gt_asymm (h : cmp x y = .gt) : cmp y x ≠ .gt :=
+theorem gt_asymm [OrientedCmp cmp] (h : cmp x y = .gt) : cmp y x ≠ .gt :=
   mt cmp_eq_gt.1 <| lt_asymm <| cmp_eq_gt.1 h
 
 end OrientedCmp
@@ -50,9 +48,7 @@ class TransCmp (cmp : α → α → Ordering) : Prop extends OrientedCmp cmp whe
   le_trans : cmp x y ≠ .gt → cmp y z ≠ .gt → cmp x z ≠ .gt
 
 namespace TransCmp
-
-variable {α} {cmp : α → α → Ordering} [TransCmp cmp] {x y z : α}
-
+variable [TransCmp cmp]
 open OrientedCmp Decidable
 
 theorem ge_trans (h₁ : cmp x y ≠ .lt) (h₂ : cmp y z ≠ .lt) : cmp x z ≠ .lt := by

--- a/Batteries/Classes/Order.lean
+++ b/Batteries/Classes/Order.lean
@@ -20,19 +20,27 @@ class OrientedCmp (cmp : α → α → Ordering) : Prop where
 
 namespace OrientedCmp
 
-theorem cmp_eq_gt [OrientedCmp cmp] : cmp x y = .gt ↔ cmp y x = .lt := by
+variable {α} {cmp : α → α → Ordering} [OrientedCmp cmp] {x y : α}
+
+theorem cmp_eq_gt : cmp x y = .gt ↔ cmp y x = .lt := by
   rw [← Ordering.swap_inj, symm]; exact .rfl
 
-theorem cmp_ne_gt [OrientedCmp cmp] : cmp x y ≠ .gt ↔ cmp y x ≠ .lt := not_congr cmp_eq_gt
+theorem cmp_ne_gt : cmp x y ≠ .gt ↔ cmp y x ≠ .lt := not_congr cmp_eq_gt
 
-theorem cmp_eq_eq_symm [OrientedCmp cmp] : cmp x y = .eq ↔ cmp y x = .eq := by
+theorem cmp_eq_eq_symm : cmp x y = .eq ↔ cmp y x = .eq := by
   rw [← Ordering.swap_inj, symm]; exact .rfl
 
-theorem cmp_refl [OrientedCmp cmp] : cmp x x = .eq :=
+theorem cmp_refl : cmp x x = .eq :=
   match e : cmp x x with
   | .lt => nomatch e.symm.trans (cmp_eq_gt.2 e)
   | .eq => rfl
   | .gt => nomatch (cmp_eq_gt.1 e).symm.trans e
+
+theorem lt_asymm (h : cmp x y = .lt) : cmp y x ≠ .lt :=
+  fun h' => nomatch h.symm.trans (cmp_eq_gt.2 h')
+
+theorem gt_asymm (h : cmp x y = .gt) : cmp y x ≠ .gt :=
+  mt cmp_eq_gt.1 <| lt_asymm <| cmp_eq_gt.1 h
 
 end OrientedCmp
 
@@ -42,18 +50,14 @@ class TransCmp (cmp : α → α → Ordering) : Prop extends OrientedCmp cmp whe
   le_trans : cmp x y ≠ .gt → cmp y z ≠ .gt → cmp x z ≠ .gt
 
 namespace TransCmp
-variable [TransCmp cmp]
+
+variable {α} {cmp : α → α → Ordering} [TransCmp cmp] {x y z : α}
+
 open OrientedCmp Decidable
 
 theorem ge_trans (h₁ : cmp x y ≠ .lt) (h₂ : cmp y z ≠ .lt) : cmp x z ≠ .lt := by
   have := @TransCmp.le_trans _ cmp _ z y x
   simp [cmp_eq_gt] at *; exact this h₂ h₁
-
-theorem lt_asymm (h : cmp x y = .lt) : cmp y x ≠ .lt :=
-  fun h' => nomatch h.symm.trans (cmp_eq_gt.2 h')
-
-theorem gt_asymm (h : cmp x y = .gt) : cmp y x ≠ .gt :=
-  mt cmp_eq_gt.1 <| lt_asymm <| cmp_eq_gt.1 h
 
 theorem le_lt_trans (h₁ : cmp x y ≠ .gt) (h₂ : cmp y z = .lt) : cmp x z = .lt :=
   byContradiction fun h₃ => ge_trans (mt cmp_eq_gt.2 h₁) h₃ h₂

--- a/Batteries/Classes/SatisfiesM.lean
+++ b/Batteries/Classes/SatisfiesM.lean
@@ -48,7 +48,7 @@ def SatisfiesM {m : Type u → Type v} [Functor m] (p : α → Prop) (x : m α) 
 namespace SatisfiesM
 
 /-- If `p` is always true, then every `x` satisfies it. -/
-theorem of_true [Applicative m] [LawfulApplicative m] {x : m α}
+theorem of_true [Functor m] [LawfulFunctor m] {x : m α}
     (h : ∀ a, p a) : SatisfiesM p x :=
   ⟨(fun a => ⟨a, h a⟩) <$> x, by simp [← comp_map, Function.comp_def]⟩
 
@@ -56,7 +56,7 @@ theorem of_true [Applicative m] [LawfulApplicative m] {x : m α}
 If `p` is always true, then every `x` satisfies it.
 (This is the strongest postcondition version of `of_true`.)
 -/
-protected theorem trivial [Applicative m] [LawfulApplicative m] {x : m α} :
+protected theorem trivial [Functor m] [LawfulFunctor m] {x : m α} :
   SatisfiesM (fun _ => True) x := of_true fun _ => trivial
 
 /-- The `SatisfiesM p x` predicate is monotonic in `p`. -/

--- a/Batteries/Classes/SatisfiesM.lean
+++ b/Batteries/Classes/SatisfiesM.lean
@@ -48,7 +48,7 @@ def SatisfiesM {m : Type u → Type v} [Functor m] (p : α → Prop) (x : m α) 
 namespace SatisfiesM
 
 /-- If `p` is always true, then every `x` satisfies it. -/
-theorem of_true [Functor m] [LawfulFunctor m] {x : m α}
+theorem of_true [Applicative m] [LawfulApplicative m] {x : m α}
     (h : ∀ a, p a) : SatisfiesM p x :=
   ⟨(fun a => ⟨a, h a⟩) <$> x, by simp [← comp_map, Function.comp_def]⟩
 
@@ -56,7 +56,7 @@ theorem of_true [Functor m] [LawfulFunctor m] {x : m α}
 If `p` is always true, then every `x` satisfies it.
 (This is the strongest postcondition version of `of_true`.)
 -/
-protected theorem trivial [Functor m] [LawfulFunctor m] {x : m α} :
+protected theorem trivial [Applicative m] [LawfulApplicative m] {x : m α} :
   SatisfiesM (fun _ => True) x := of_true fun _ => trivial
 
 /-- The `SatisfiesM p x` predicate is monotonic in `p`. -/

--- a/Batteries/Data/RBMap/Lemmas.lean
+++ b/Batteries/Data/RBMap/Lemmas.lean
@@ -83,11 +83,11 @@ class IsCut (cmp : α → α → Ordering) (cut : α → Ordering) : Prop where
 
 theorem IsCut.lt_trans [IsCut cmp cut] [TransCmp cmp]
     (H : cmp x y = .lt) : cut x = .lt → cut y = .lt :=
-  IsCut.le_lt_trans <| TransCmp.gt_asymm <| OrientedCmp.cmp_eq_gt.2 H
+  IsCut.le_lt_trans <| OrientedCmp.gt_asymm <| OrientedCmp.cmp_eq_gt.2 H
 
 theorem IsCut.gt_trans [IsCut cmp cut] [TransCmp cmp]
     (H : cmp x y = .lt) : cut y = .gt → cut x = .gt :=
-  IsCut.le_gt_trans <| TransCmp.gt_asymm <| OrientedCmp.cmp_eq_gt.2 H
+  IsCut.le_gt_trans <| OrientedCmp.gt_asymm <| OrientedCmp.cmp_eq_gt.2 H
 
 theorem IsCut.congr [IsCut cmp cut] [TransCmp cmp] (H : cmp x y = .eq) : cut x = cut y := by
   cases ey : cut y
@@ -495,17 +495,17 @@ theorem Ordered.upperBound?_least_ub [@TransCmp α cmp] [IsCut cmp cut] (h : Ord
   | node _ _ _ _ ihl ihr =>
     simp [upperBound?]; split <;> rename_i hv <;> rintro h₁ (rfl | hy' | hy') hx h₂
     · rcases upperBound?_mem_ub h₁ with h₁ | ⟨⟨⟩⟩
-      · cases TransCmp.lt_asymm h₂ (All_def.1 h.1 _ h₁).1
-      · cases TransCmp.lt_asymm h₂ h₂
+      · cases OrientedCmp.lt_asymm h₂ (All_def.1 h.1 _ h₁).1
+      · cases OrientedCmp.lt_asymm h₂ h₂
     · exact ihl h.2.2.1 (by rintro _ ⟨⟨⟩⟩; exact h.1) h₁ hy' hx h₂
-    · refine (TransCmp.lt_asymm h₂ ?_).elim; have := (All_def.1 h.2.1 _ hy').1
+    · refine (OrientedCmp.lt_asymm h₂ ?_).elim; have := (All_def.1 h.2.1 _ hy').1
       rcases upperBound?_mem_ub h₁ with h₁ | ⟨⟨⟩⟩
       · exact TransCmp.lt_trans (All_def.1 h.1 _ h₁).1 this
       · exact this
     · exact hv
     · exact IsCut.gt_trans (cut := cut) (cmp := cmp) (All_def.1 h.1 _ hy').1 hv
     · exact ihr h.2.2.2 (fun h => (hub h).2.2) h₁ hy' hx h₂
-    · cases h₁; cases TransCmp.lt_asymm h₂ h₂
+    · cases h₁; cases OrientedCmp.lt_asymm h₂ h₂
     · cases h₁; cases hx.symm.trans hv
     · cases h₁; cases hx.symm.trans hv
 


### PR DESCRIPTION
This PR generalizes some typeclasses. They were found using a linter.

[#mathlib4 > Linter for generalizing type class hypotheses](https://leanprover.zulipchat.com/#narrow/channel/287929-mathlib4/topic/Linter.20for.20generalizing.20type.20class.20hypotheses)