### PR TITLE
chore: mark `Nat.sqrt.iter` as semireducible

### DIFF
--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -94,7 +94,7 @@ def sqrt (n : Nat) : Nat :=
   iter n (n / 2)
 where
   /-- Auxiliary for `sqrt`. If `guess` is greater than the integer square root of `n`,
-  returns the integer square root of `n`. 
+  returns the integer square root of `n`.
 
   By default this well-founded recursion would be irreducible.
   This prevents use `decide` to resolve `Nat.sqrt n` for small values of `n`,

--- a/Batteries/Data/Nat/Basic.lean
+++ b/Batteries/Data/Nat/Basic.lean
@@ -94,8 +94,12 @@ def sqrt (n : Nat) : Nat :=
   iter n (n / 2)
 where
   /-- Auxiliary for `sqrt`. If `guess` is greater than the integer square root of `n`,
-  returns the integer square root of `n`. -/
-  iter (n guess : Nat) : Nat :=
+  returns the integer square root of `n`. 
+
+  By default this well-founded recursion would be irreducible.
+  This prevents use `decide` to resolve `Nat.sqrt n` for small values of `n`,
+  so we mark this as `@[semireducible]`. -/
+  @[semireducible] iter (n guess : Nat) : Nat :=
     let next := (guess + n / guess) / 2
     if _h : next < guess then
       iter n next


### PR DESCRIPTION

This definition has become irreducible in v4.19.0-rc2, which blocks reduction of `Nat.sqrt`, as well as `IsSquare` and `Nat.minFac` in mathlib, both functions which are used for decidability there. Furthermore, marking `Nat.sqrt.iter` as `semireducible` locally does not make those reduce appropriately. Further still, `decide +kernel` - which is meant to ignore irreducible tags - fails to see through `Nat.sqrt.iter`, so the only solution is this one.