### PR TITLE
chore: deprecate mis-cased Lean.MVarId.assignIfDefeq

### DIFF
--- a/Batteries/Tactic/Exact.lean
+++ b/Batteries/Tactic/Exact.lean
@@ -13,7 +13,10 @@ open Lean Meta
 `MetaM` version of `Lean.Elab.Tactic.evalExact`: add `mvarId := x` to the metavariable assignment.
 This method wraps `Lean.MVarId.assign`, checking whether `mvarId` is already assigned, and whether
 the expression has the right type. -/
-def Lean.MVarId.assignIfDefeq (g : MVarId) (e : Expr) : MetaM Unit := do
+def Lean.MVarId.assignIfDefEq (g : MVarId) (e : Expr) : MetaM Unit := do
   guard <| ← isDefEq (← g.getType) (← inferType e)
-  g.checkNotAssigned `assignIfDefeq
+  g.checkNotAssigned `assignIfDefEq
   g.assign e
+
+@[deprecated Lean.MVarId.assignIfDefEq (since := "2025-04-09")] 
+abbrev Lean.MVarId.assignIfDefeq := Lean.MVarId.assignIfDefEq

--- a/Batteries/Tactic/Exact.lean
+++ b/Batteries/Tactic/Exact.lean
@@ -18,5 +18,5 @@ def Lean.MVarId.assignIfDefEq (g : MVarId) (e : Expr) : MetaM Unit := do
   g.checkNotAssigned `assignIfDefEq
   g.assign e
 
-@[deprecated Lean.MVarId.assignIfDefEq (since := "2025-04-09")] 
+@[deprecated Lean.MVarId.assignIfDefEq (since := "2025-04-09")]
 abbrev Lean.MVarId.assignIfDefeq := Lean.MVarId.assignIfDefEq

--- a/Batteries/Tactic/Exact.lean
+++ b/Batteries/Tactic/Exact.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro
 -/
 import Lean.Meta.Tactic.Util
+import Batteries.Tactic.Alias
 
 /-! # `exact` tactic (`MetaM` version) -/
 
@@ -18,5 +19,5 @@ def Lean.MVarId.assignIfDefEq (g : MVarId) (e : Expr) : MetaM Unit := do
   g.checkNotAssigned `assignIfDefEq
   g.assign e
 
-@[deprecated Lean.MVarId.assignIfDefEq (since := "2025-04-09")]
-abbrev Lean.MVarId.assignIfDefeq := Lean.MVarId.assignIfDefEq
+@[deprecated (since := "2025-04-09")]
+alias Lean.MVarId.assignIfDefeq := Lean.MVarId.assignIfDefEq


### PR DESCRIPTION
All the functions in core use the spelling `DefEq`, so batteries should match them.