### PR TITLE
feat: add `Vector.tail` API

### DIFF
--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -55,7 +55,7 @@ theorem toArray_injective : ∀ {v w : Vector α n}, v.toArray = w.toArray → v
 
 /-! ### getElem lemmas -/
 
-theorem getElem_tail {v : Vector α n} {i : Nat} {hi : i < n - 1} :
+theorem getElem_tail {v : Vector α n} {i : Nat} (hi : i < n - 1) :
     (v.tail)[i] = v[i + 1] := match n with
   | 0 => by contradiction
   | _ + 1 => (getElem_congr_coll tail_succ).trans (getElem_eraseIdx (Nat.zero_lt_succ _) hi)
@@ -90,3 +90,6 @@ theorem getElem_tail {v : Vector α n} {i : Nat} {hi : i < n - 1} :
 @[simp] theorem get_cast (v : Vector α m) (h : m = n) (i : Fin n) :
     (v.cast h).get i = v.get (i.cast h.symm) :=
   getElem_cast _
+
+@[simp] theorem get_tail (v : Vector α (n + 1)) (i : Fin n) :
+    (v.tail).get i = v.get i.succ := getElem_tail _

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -43,22 +43,21 @@ theorem toArray_injective : ∀ {v w : Vector α n}, v.toArray = w.toArray → v
 
 /-! ### tail lemmas -/
 
-@[simp] theorem tail_zero {v : Vector α 0} :
+theorem tail_zero {v : Vector α 0} :
     v.tail = #v[] := Vector.eq_empty
-@[simp] theorem tail_succ {v : Vector α (n + 1)} :
-    v.tail = v.eraseIdx 0 := dif_pos (Nat.zero_lt_succ _)
+theorem tail_ne_zero [NeZero n] {v : Vector α n} :
+    v.tail = v.eraseIdx 0 n.pos_of_neZero := dif_pos _
 
 @[simp] theorem toList_tail {v : Vector α n} :
     v.tail.toList = v.toList.tail := match n with
   | 0 => by simp only [tail_zero, Vector.eq_empty, List.tail_nil]
-  | _ + 1 => by simp only [tail_succ, Vector.toList_eraseIdx, List.eraseIdx_zero]
+  | _ + 1 => by simp only [tail_ne_zero, Vector.toList_eraseIdx, List.eraseIdx_zero]
 
 /-! ### getElem lemmas -/
 
 theorem getElem_tail {v : Vector α n} {i : Nat} (hi : i < n - 1) :
     (v.tail)[i] = v[i + 1] := match n with
-  | 0 => by contradiction
-  | _ + 1 => (getElem_congr_coll tail_succ).trans (getElem_eraseIdx (Nat.zero_lt_succ _) hi)
+  | _ + 1 => getElem_congr_coll tail_ne_zero |>.trans <| getElem_eraseIdx (Nat.zero_lt_succ _) hi
 
 /-! ### get lemmas -/
 
@@ -92,4 +91,4 @@ theorem getElem_tail {v : Vector α n} {i : Nat} (hi : i < n - 1) :
   getElem_cast _
 
 @[simp] theorem get_tail (v : Vector α (n + 1)) (i : Fin n) :
-    (v.tail).get i = v.get i.succ := getElem_tail _
+    v.tail.get i = v.get i.succ := getElem_tail _

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -41,6 +41,25 @@ theorem toArray_injective : ∀ {v w : Vector α n}, v.toArray = w.toArray → v
 @[deprecated (since := "2024-11-25")] alias toArray_swapN := toArray_swap
 @[deprecated (since := "2024-11-25")] alias toArray_swapAtN := toArray_swapAt
 
+/-! ### tail lemmas -/
+
+@[simp] theorem tail_zero {v : Vector α 0} :
+    v.tail = #v[] := Vector.eq_empty
+@[simp] theorem tail_succ {v : Vector α (n + 1)} :
+    v.tail = v.eraseIdx 0 := dif_pos (Nat.zero_lt_succ _)
+
+@[simp] theorem toList_tail {v : Vector α n} :
+    v.tail.toList = v.toList.tail := match n with
+  | 0 => by simp only [tail_zero, Vector.eq_empty, List.tail_nil]
+  | _ + 1 => by simp only [tail_succ, Vector.toList_eraseIdx, List.eraseIdx_zero]
+
+/-! ### getElem lemmas -/
+
+theorem getElem_tail {v : Vector α n} {i : Nat} {hi : i < n - 1} :
+    (v.tail)[i] = v[i + 1] := match n with
+  | 0 => by contradiction
+  | _ + 1 => (getElem_congr_coll tail_succ).trans (getElem_eraseIdx (Nat.zero_lt_succ _) hi)
+
 /-! ### get lemmas -/
 
 @[simp] theorem get_push_last (v : Vector α n) (a : α) :

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -43,20 +43,22 @@ theorem toArray_injective : ∀ {v w : Vector α n}, v.toArray = w.toArray → v
 
 /-! ### tail lemmas -/
 
-theorem tail_zero {v : Vector α 0} :
-    v.tail = #v[] := Vector.eq_empty
+theorem tail_zero {v : Vector α 0} : v.tail = #v[] := Vector.eq_empty
+
 theorem tail_ne_zero [NeZero n] {v : Vector α n} :
     v.tail = v.eraseIdx 0 n.pos_of_neZero := dif_pos _
 
 @[simp] theorem toList_tail {v : Vector α n} :
-    v.tail.toList = v.toList.tail := match n with
+    v.tail.toList = v.toList.tail :=
+  match n with
   | 0 => by simp only [tail_zero, Vector.eq_empty, List.tail_nil]
   | _ + 1 => by simp only [tail_ne_zero, Vector.toList_eraseIdx, List.eraseIdx_zero]
 
 /-! ### getElem lemmas -/
 
 theorem getElem_tail {v : Vector α n} {i : Nat} (hi : i < n - 1) :
-    (v.tail)[i] = v[i + 1] := match n with
+    v.tail[i] = v[i + 1] :=
+  match n with
   | _ + 1 => getElem_congr_coll tail_ne_zero |>.trans <| getElem_eraseIdx (Nat.zero_lt_succ _) hi
 
 /-! ### get lemmas -/


### PR DESCRIPTION
There are no lemmas for interacting with `Vector.tail`. This PR adds some basic API for it. (I also think we should define it using a match rather than an if-then-else but that's a core problem).