### PR TITLE
fix: Rename `tail` lemmas

### DIFF
--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -51,8 +51,8 @@ theorem tail_eq_of_ne_zero [NeZero n] {v : Vector α n} :
 @[simp] theorem toList_tail {v : Vector α n} :
     v.tail.toList = v.toList.tail :=
   match n with
-  | 0 => by simp only [tail_eq_of_zero, Vector.eq_empty, List.tail_nil]
-  | _ + 1 => by simp only [tail_eq_of_ne_zero, Vector.toList_eraseIdx, List.eraseIdx_zero]
+  | 0 => by simp [Vector.eq_empty]
+  | _ + 1 => by simp [tail_eq_of_ne_zero]
 
 /-! ### getElem lemmas -/
 

--- a/Batteries/Data/Vector/Lemmas.lean
+++ b/Batteries/Data/Vector/Lemmas.lean
@@ -43,23 +43,25 @@ theorem toArray_injective : ∀ {v w : Vector α n}, v.toArray = w.toArray → v
 
 /-! ### tail lemmas -/
 
-theorem tail_zero {v : Vector α 0} : v.tail = #v[] := Vector.eq_empty
+theorem tail_eq_of_zero {v : Vector α 0} : v.tail = #v[] := Vector.eq_empty
 
-theorem tail_ne_zero [NeZero n] {v : Vector α n} :
+theorem tail_eq_of_ne_zero [NeZero n] {v : Vector α n} :
     v.tail = v.eraseIdx 0 n.pos_of_neZero := dif_pos _
 
 @[simp] theorem toList_tail {v : Vector α n} :
     v.tail.toList = v.toList.tail :=
   match n with
-  | 0 => by simp only [tail_zero, Vector.eq_empty, List.tail_nil]
-  | _ + 1 => by simp only [tail_ne_zero, Vector.toList_eraseIdx, List.eraseIdx_zero]
+  | 0 => by simp only [tail_eq_of_zero, Vector.eq_empty, List.tail_nil]
+  | _ + 1 => by simp only [tail_eq_of_ne_zero, Vector.toList_eraseIdx, List.eraseIdx_zero]
 
 /-! ### getElem lemmas -/
 
 theorem getElem_tail {v : Vector α n} {i : Nat} (hi : i < n - 1) :
     v.tail[i] = v[i + 1] :=
   match n with
-  | _ + 1 => getElem_congr_coll tail_ne_zero |>.trans <| getElem_eraseIdx (Nat.zero_lt_succ _) hi
+  | _ + 1 =>
+    getElem_congr_coll tail_eq_of_ne_zero |>.trans <|
+    getElem_eraseIdx (Nat.zero_lt_succ _) hi
 
 /-! ### get lemmas -/
 


### PR DESCRIPTION
Renames two lemmas added in  #1234 that were misnamed.