### PR TITLE
fix: reintroduce `MonadLift Id m` instance

### DIFF
--- a/Batteries.lean
+++ b/Batteries.lean
@@ -13,6 +13,7 @@ import Batteries.Control.ForInStep.Basic
 import Batteries.Control.ForInStep.Lemmas
 import Batteries.Control.Lemmas
 import Batteries.Control.Monad
+import Batteries.Control.MonadLift
 import Batteries.Control.Nondet.Basic
 import Batteries.Control.OptionT
 import Batteries.Data.Array

--- a/Batteries/Control/MonadLift.lean
+++ b/Batteries/Control/MonadLift.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 namespace Id
 
 /-- The `pure` operation of a monad `m` can be seen as a lifting operation from `Id` to `m`. -/

--- a/Batteries/Control/MonadLift.lean
+++ b/Batteries/Control/MonadLift.lean
@@ -1,0 +1,17 @@
+/-
+Copyright (c) 2025 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+namespace Id
+
+/-- The `pure` operation of a monad `m` can be seen as a lifting operation from `Id` to `m`. -/
+instance [Pure m] : MonadLift Id m where
+  monadLift := pure
+
+/-- The lifting from `Id` to a lawful monad `m` induced by `pure` is lawful. -/
+instance [Monad m] [LawfulMonad m] : LawfulMonadLift Id m where
+  monadLift_pure := fun a => by simp [MonadLift.monadLift, pure]
+  monadLift_bind := fun x f => by simp [MonadLift.monadLift, bind]
+
+end Id


### PR DESCRIPTION
This PR reintroduces the generic `MonadLift Id m` instance.

During the upstreaming of `LawfulMonadLift` (https://github.com/leanprover-community/batteries/pull/1242), the initial plan was to also upstream the `MonadLift Id m` instance from Batteries. However, because this turned out to bring some performance problems with it, I decided not to include this instance in the upstreaming PR. Unfortunately, the associated PR-testing branch has [been](https://github.com/leanprover-community/batteries/commit/3aafa48516440d6038efb626660c74dec6e640da) merged without the [change reintroducing said instance](https://github.com/leanprover-community/batteries/pull/1242). So this PR fixes the accidental removal. I apologize, I should have waited with merging into `lean4` until https://github.com/leanprover-community/batteries/pull/1242 is merged.

Note that this PR simply restores the previous state of the API. I'd prefer to decouple this from discussions on how to improve or upstream this instance.