### PR TITLE
fix: do not create Decidable subgoals from by_contra

### DIFF
--- a/Batteries/Tactic/Init.lean
+++ b/Batteries/Tactic/Init.lean
@@ -42,8 +42,8 @@ macro (name := byContra) tk:"by_contra" e?:(ppSpace colGt binderIdent)? : tactic
     | none => Unhygienic.run `(_%$tk)
   `(tactic| first
     | guard_target = Not _; intro $e:term
-    | refine (Decidable.byContradiction fun $e => ?_ :)
-    | refine (Classical.byContradiction fun $e => ?_ :))
+    | refine @Decidable.byContradiction _ _ fun $e => ?_
+    | refine @Classical.byContradiction _ fun $e => ?_)
 
 /--
 Given a proof `h` of `p`, `absurd h` changes the goal to `⊢ ¬ p`.

--- a/BatteriesTest/by_contra.lean
+++ b/BatteriesTest/by_contra.lean
@@ -14,7 +14,7 @@ private def decid (P : Prop) [Decidable P] (x : P) : P := by
 
 example (P : Prop) [Decidable P] : nonDecid P = decid P := by
   delta nonDecid decid
-  guard_target =
+  guard_target =ₛ
     (fun x : P => Classical.byContradiction fun h => h x) =
     (fun x : P => Decidable.byContradiction fun h => h x)
   rfl
@@ -28,3 +28,25 @@ example (P : Prop) : {_ : P} → P := by
   by_contra
   guard_hyp ‹_› : ¬(P → P)
   exact ‹¬(P → P)› id
+
+/-!
+https://github.com/leanprover-community/batteries/issues/1196:
+
+Previously the second error had a `Decidable True` subgoal, which only appeared in the presence of
+the first unclosed goal.
+-/
+/--
+error: unsolved goals
+case left
+⊢ True
+---
+error: unsolved goals
+case right
+x✝ : ¬True
+⊢ False
+-/
+#guard_msgs in
+example : True ∧ True := by
+  constructor
+  · skip
+  · by_contra


### PR DESCRIPTION
This works around https://github.com/leanprover/lean4/issues/8643.

Also adjusts a test to actually verify that the proof uses decidability, rather than using proof irrelevence.

Fixes #1196