### PR TITLE
fix(simpNF): use correct Meta configuration

### DIFF
--- a/Batteries/Tactic/Lint/Simp.lean
+++ b/Batteries/Tactic/Lint/Simp.lean
@@ -102,6 +102,7 @@ see note [simp-normal form] for tips how to debug this.
 https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20form"
   test := fun declName => do
     unless ← isSimpTheorem declName do return none
+    withConfig Elab.Term.setElabConfig do
     checkAllSimpTheoremInfos (← getConstInfo declName).type fun { lhs, rhs, hyps, .. } => do
       -- we use `simp [*]` so that simp lemmas with hypotheses apply to themselves
       -- higher order simp lemmas need `simp +contextual [*]` to be able to apply to themselves

--- a/Batteries/Tactic/Lint/Simp.lean
+++ b/Batteries/Tactic/Lint/Simp.lean
@@ -103,85 +103,85 @@ https://leanprover-community.github.io/mathlib_docs/notes.html#simp-normal%20for
   test := fun declName => do
     unless ← isSimpTheorem declName do return none
     withConfig Elab.Term.setElabConfig do
-    checkAllSimpTheoremInfos (← getConstInfo declName).type fun { lhs, rhs, hyps, .. } => do
-      -- we use `simp [*]` so that simp lemmas with hypotheses apply to themselves
-      -- higher order simp lemmas need `simp +contextual [*]` to be able to apply to themselves
-      let mut simpTheorems ← getSimpTheorems
-      let mut higherOrder := false
-      for h in hyps do
-        if ← isCondition h then
-          simpTheorems ← simpTheorems.add (.fvar h.fvarId!) #[] h
-          if !higherOrder then
-            higherOrder ← forallTelescope (← inferType h) fun hyps _ => hyps.anyM isCondition
-      let ctx ← Simp.mkContext (config := { contextual := higherOrder })
-        (simpTheorems := #[simpTheorems]) (congrTheorems := ← getSimpCongrTheorems)
-      let isRfl ← isRflTheorem declName
-      let simplify (e : Expr) (ctx : Simp.Context) (stats : Simp.Stats := {}) :
-          MetaM (Simp.Result × Simp.Stats) := do
-        if !isRfl then
-          simp e ctx (stats := stats)
-        else
-          let (e, s) ← dsimp e ctx (stats := stats)
-          return (Simp.Result.mk e .none .true, s)
-      let ({ expr := lhs', proof? := prf1, .. }, prf1Stats) ←
-        decorateError "simplify fails on left-hand side:" <| simplify lhs ctx
-      if prf1Stats.usedTheorems.map.contains (.decl declName) then return none
-      let ({ expr := rhs', .. }, stats) ←
-        decorateError "simplify fails on right-hand side:" <| simplify rhs ctx prf1Stats
-      let lhs'EqRhs' ← isSimpEq lhs' rhs' (whnfFirst := false)
-      let lhsInNF ← isSimpEq lhs' lhs
-      let simpName := if !isRfl then "simp" else "dsimp"
-      if lhs'EqRhs' then
-        if prf1.isNone then return none -- TODO: FP rewriting foo.eq_2 using `simp only [foo]`
-        return m!"\
-          {simpName} can prove this:\
-          \n  by {← formatLemmas stats.usedTheorems simpName higherOrder}\
-          \nOne of the lemmas above could be a duplicate.\
-          \nIf that's not the case try reordering lemmas or adding @[priority]."
-      else if ¬ lhsInNF then
-        return m!"\
-          Left-hand side simplifies from\
-          \n  {lhs}\
-          \nto\
-          \n  {lhs'}\
-          \nusing\
-          \n  {← formatLemmas prf1Stats.usedTheorems simpName higherOrder}\
-          \nTry to change the left-hand side to the simplified term!"
-      else if lhs == lhs' then
-        let lhsType ← inferType lhs
-        let mut hints := m!""
+      checkAllSimpTheoremInfos (← getConstInfo declName).type fun { lhs, rhs, hyps, .. } => do
+        -- we use `simp [*]` so that simp lemmas with hypotheses apply to themselves
+        -- higher order simp lemmas need `simp +contextual [*]` to be able to apply to themselves
+        let mut simpTheorems ← getSimpTheorems
+        let mut higherOrder := false
         for h in hyps do
-          let ldecl ← h.fvarId!.getDecl
-          let mut name := ldecl.userName
-          if name.hasMacroScopes then
-            name := sanitizeName name |>.run' { options := ← getOptions }
-          if ← isProp ldecl.type then
-            -- improve the error message if the hypothesis isn't in `simp` normal form
-            let ({ expr := hType', .. }, stats) ←
-              decorateError m!"simplify fails on hypothesis ({name} : {ldecl.type}):" <|
-                simplify ldecl.type (← Simp.Context.mkDefault)
-            unless ← isSimpEq hType' ldecl.type do
-              hints := hints ++ m!"\
-                \nThe simp lemma may be invalid because hypothesis {name} simplifies from\
-                \n  {ldecl.type}\
-                \nto\
-                \n  {hType'}\
-                \nusing\
-                \n  {← formatLemmas stats.usedTheorems simpName none}\
-                \nTry to change the hypothesis to the simplified term!"
+          if ← isCondition h then
+            simpTheorems ← simpTheorems.add (.fvar h.fvarId!) #[] h
+            if !higherOrder then
+              higherOrder ← forallTelescope (← inferType h) fun hyps _ => hyps.anyM isCondition
+        let ctx ← Simp.mkContext (config := { contextual := higherOrder })
+          (simpTheorems := #[simpTheorems]) (congrTheorems := ← getSimpCongrTheorems)
+        let isRfl ← isRflTheorem declName
+        let simplify (e : Expr) (ctx : Simp.Context) (stats : Simp.Stats := {}) :
+            MetaM (Simp.Result × Simp.Stats) := do
+          if !isRfl then
+            simp e ctx (stats := stats)
           else
-            -- improve the error message if the argument can't be filled in by `simp`
-            if !ldecl.binderInfo.isInstImplicit &&
-                !lhs.containsFVar h.fvarId! && !lhsType.containsFVar h.fvarId! then
-              hints := hints ++ m!"\
-                \nThe simp lemma is invalid because the value of argument\
-                \n  {name} : {ldecl.type}\
-                \ncannot be inferred by `simp`."
-        return m!"\
-          Left-hand side does not simplify, when using the simp lemma on itself.
-          \nThis usually means that it will never apply.{hints}\n"
-      else
-        return none
+            let (e, s) ← dsimp e ctx (stats := stats)
+            return (Simp.Result.mk e .none .true, s)
+        let ({ expr := lhs', proof? := prf1, .. }, prf1Stats) ←
+          decorateError "simplify fails on left-hand side:" <| simplify lhs ctx
+        if prf1Stats.usedTheorems.map.contains (.decl declName) then return none
+        let ({ expr := rhs', .. }, stats) ←
+          decorateError "simplify fails on right-hand side:" <| simplify rhs ctx prf1Stats
+        let lhs'EqRhs' ← isSimpEq lhs' rhs' (whnfFirst := false)
+        let lhsInNF ← isSimpEq lhs' lhs
+        let simpName := if !isRfl then "simp" else "dsimp"
+        if lhs'EqRhs' then
+          if prf1.isNone then return none -- TODO: FP rewriting foo.eq_2 using `simp only [foo]`
+          return m!"\
+            {simpName} can prove this:\
+            \n  by {← formatLemmas stats.usedTheorems simpName higherOrder}\
+            \nOne of the lemmas above could be a duplicate.\
+            \nIf that's not the case try reordering lemmas or adding @[priority]."
+        else if ¬ lhsInNF then
+          return m!"\
+            Left-hand side simplifies from\
+            \n  {lhs}\
+            \nto\
+            \n  {lhs'}\
+            \nusing\
+            \n  {← formatLemmas prf1Stats.usedTheorems simpName higherOrder}\
+            \nTry to change the left-hand side to the simplified term!"
+        else if lhs == lhs' then
+          let lhsType ← inferType lhs
+          let mut hints := m!""
+          for h in hyps do
+            let ldecl ← h.fvarId!.getDecl
+            let mut name := ldecl.userName
+            if name.hasMacroScopes then
+              name := sanitizeName name |>.run' { options := ← getOptions }
+            if ← isProp ldecl.type then
+              -- improve the error message if the hypothesis isn't in `simp` normal form
+              let ({ expr := hType', .. }, stats) ←
+                decorateError m!"simplify fails on hypothesis ({name} : {ldecl.type}):" <|
+                  simplify ldecl.type (← Simp.Context.mkDefault)
+              unless ← isSimpEq hType' ldecl.type do
+                hints := hints ++ m!"\
+                  \nThe simp lemma may be invalid because hypothesis {name} simplifies from\
+                  \n  {ldecl.type}\
+                  \nto\
+                  \n  {hType'}\
+                  \nusing\
+                  \n  {← formatLemmas stats.usedTheorems simpName none}\
+                  \nTry to change the hypothesis to the simplified term!"
+            else
+              -- improve the error message if the argument can't be filled in by `simp`
+              if !ldecl.binderInfo.isInstImplicit &&
+                  !lhs.containsFVar h.fvarId! && !lhsType.containsFVar h.fvarId! then
+                hints := hints ++ m!"\
+                  \nThe simp lemma is invalid because the value of argument\
+                  \n  {name} : {ldecl.type}\
+                  \ncannot be inferred by `simp`."
+          return m!"\
+            Left-hand side does not simplify, when using the simp lemma on itself.
+            \nThis usually means that it will never apply.{hints}\n"
+        else
+          return none
 
 library_note "simp-normal form" /--
 This note gives you some tips to debug any errors that the simp-normal form linter raises.

--- a/BatteriesTest/lint_simpNF.lean
+++ b/BatteriesTest/lint_simpNF.lean
@@ -51,4 +51,20 @@ example {β : Type _} (l : List α) (f : α → β) :
 
 end List
 
+/-! This tests that `simpNF` is not accidentally using `quasiPatternApprox := true`. -/
+
+def eqToFun {X Y : Type} (p : X = Y) : X → Y := by rw [p]; exact id
+
+@[simp]
+theorem eqToFun_comp_eq_self {β} {X : Type} {f : β → Type}
+    (z : ∀ b, X → f b) {j j' : β} (w : j = j') :
+    eqToFun (by simp [w]) ∘ z j' = z j := by
+  cases w; rfl
+
+@[simp]
+theorem eqToFun_comp_iso_hom_eq_self {β} {X : Type} {f : β → Type}
+    (z : ∀ b, X ≃ f b) {j j' : β} (w : j = j') :
+    eqToFun (by simp [w]) ∘ (z j').toFun = (z j).toFun := by
+  cases w; rfl
+
 #lint- only simpNF


### PR DESCRIPTION
`simpNF` was claiming `simp` could prove something when in reality `simp` couldn't prove it.

This was because `simpNF` used the wrong `Meta.Config`, so this PR fixes that.