### PR TITLE
fix: use lakefile.toml instead of lakefile.lean in discover workflow

### DIFF
--- a/.github/workflows/discover-lean-pr-testing.yml
+++ b/.github/workflows/discover-lean-pr-testing.yml
@@ -108,7 +108,7 @@ jobs:
             DIFF_FILES=$(git diff --name-only "origin/nightly-testing...$BRANCH")
 
             # Check if the diff contains files other than the specified ones
-            if echo "$DIFF_FILES" | grep -v -e 'lake-manifest.json' -e 'lakefile.lean' -e 'lean-toolchain'; then
+            if echo "$DIFF_FILES" | grep -v -e 'lake-manifest.json' -e 'lakefile.toml' -e 'lean-toolchain'; then
                 # Extract the actual branch name
                 ACTUAL_BRANCH=${BRANCH#origin/}
 


### PR DESCRIPTION
This fixes the discover-lean-pr-testing workflow which was incorrectly filtering branches by looking for changes to `lakefile.lean`, but Batteries uses `lakefile.toml`.

## Problem
The workflow was copied from Mathlib's equivalent workflow, but this key difference wasn't properly adapted. This caused the branch relevance detection to work incorrectly - branches that should have been automatically merged were either being skipped or incorrectly flagged as needing manual review.

## Solution
Changed the file filtering logic to use `lakefile.toml` instead of `lakefile.lean` in the branch diff check.

