### PR TITLE
chore: update CI to use mathlib4-nightly-testing fork

### DIFF
--- a/.github/workflows/test_mathlib.yml
+++ b/.github/workflows/test_mathlib.yml
@@ -35,6 +35,12 @@ jobs:
           ref: master
           fetch-depth: 0
 
+      - name: Add nightly-testing remote
+        if: steps.pr-info.outputs.pullRequestNumber != '' && steps.pr-info.outputs.targetBranch == 'main'
+        run: |
+          git remote add nightly-testing https://github.com/leanprover-community/mathlib4-nightly-testing.git
+          git fetch nightly-testing
+
       - name: Install elan
         if: steps.pr-info.outputs.pullRequestNumber != '' && steps.pr-info.outputs.targetBranch == 'main'
         run: |
@@ -85,4 +91,4 @@ jobs:
         env:
           PR_NUMBER: ${{ steps.pr-info.outputs.pullRequestNumber }}
         run: |
-          git push origin batteries-pr-testing-$PR_NUMBER
+          git push nightly-testing batteries-pr-testing-$PR_NUMBER


### PR DESCRIPTION
This goes along with https://github.com/leanprover/lean4/pull/8933 and https://github.com/leanprover-community/mathlib4/pull/26286, see zulip discussion at [#nightly-testing > moving to a fork](https://leanprover.zulipchat.com/#narrow/channel/428973-nightly-testing/topic/moving.20to.20a.20fork/with/525242440)