### PR TITLE
fix batteries after Subarray->Slice migration

### DIFF
--- a/Batteries/Data/Array/Basic.lean
+++ b/Batteries/Data/Array/Basic.lean
@@ -163,9 +163,9 @@ def popHead? (as : Subarray α) : Option (α × Subarray α) :=
     then
       let head := as.array[as.start]'(Nat.lt_of_lt_of_le h as.stop_le_array_size)
       let tail :=
-        { as with
-          start := as.start + 1
-          start_le_stop := Nat.le_of_lt_succ $ Nat.succ_lt_succ h }
+        ⟨{ as.internalRepresentation with
+           start := as.start + 1
+           start_le_stop := Nat.le_of_lt_succ $ Nat.succ_lt_succ h }⟩
       some (head, tail)
     else
       none


### PR DESCRIPTION
We changed the internal representation of `Subarray` while preserving all of its functionality. However, the constructor cannot be used as before. This PR fixes a call of `Subarray.mk` in Batteries. See: https://github.com/leanprover/lean4/pull/8947