### PR TITLE
feat: make `unusedHavesSuffices` linter only apply to propositions

### DIFF
--- a/Batteries/Tactic/Lint/Misc.lean
+++ b/Batteries/Tactic/Lint/Misc.lean
@@ -225,7 +225,7 @@ with rfl when elaboration results in a different term than the user intended. -/
       return none
 
 /--
-Return a list of unused `let_fun` terms in an expression.
+Return a list of unused `let_fun` terms in an expression that introduce proofs.
 -/
 def findUnusedHaves (e : Expr) : MetaM (Array MessageData) := do
   let res ← IO.mkRef #[]
@@ -234,6 +234,7 @@ def findUnusedHaves (e : Expr) : MetaM (Array MessageData) := do
     | some (n, t, _, b) =>
       if n.isInternal then return
       if b.hasLooseBVars then return
+      unless ← Meta.isProp t do return
       let msg ← addMessageContextFull m!"unnecessary have {n.eraseMacroScopes} : {t}"
       res.modify (·.push msg)
     | _ => return


### PR DESCRIPTION
The `unusedHavesSuffices` linter error talks about proofs, so this PR adds in a check that the `have` is indeed introducing a proposition. This will be necessary in the next release because Lean will convert `let`s to `have`s automatically to cache which ones are nondependent, and, for example, `do` notation can elaborate into expressions that have unused `let`s, which we don't want to be flagged by this linter.

After the next Lean release, this linter should be updated look for nondependent `Expr.letE` expressions rather than `letFun`s.