### PR TITLE
style: replace `HEq x y` with `x ≍ y`

### DIFF
--- a/Batteries/Logic.lean
+++ b/Batteries/Logic.lean
@@ -26,7 +26,7 @@ end Classical
 
 /-! ## equality -/
 
-theorem heq_iff_eq {a b : α} : HEq a b ↔ a = b := ⟨eq_of_heq, heq_of_eq⟩
+theorem heq_iff_eq {a b : α} : a ≍ b ↔ a = b := ⟨eq_of_heq, heq_of_eq⟩
 
 @[simp] theorem eq_rec_constant {α : Sort _} {a a' : α} {β : Sort _} (y : β) (h : a = a') :
     (@Eq.rec α a (fun _ _ => β) y a' h) = y := by cases h; rfl
@@ -65,10 +65,10 @@ alias congr_fun := congrFun
 alias congr_fun₂ := congrFun₂
 alias congr_fun₃ := congrFun₃
 
-theorem heq_of_cast_eq : ∀ (e : α = β) (_ : cast e a = a'), HEq a a'
+theorem heq_of_cast_eq : ∀ (e : α = β) (_ : cast e a = a'), a ≍ a'
   | rfl, rfl => .rfl
 
-theorem cast_eq_iff_heq : cast e a = a' ↔ HEq a a' :=
+theorem cast_eq_iff_heq : cast e a = a' ↔ a ≍ a' :=
   ⟨heq_of_cast_eq _, fun h => by cases h; rfl⟩
 
 theorem eqRec_eq_cast {α : Sort _} {a : α} {motive : (a' : α) → a = a' → Sort _}
@@ -78,20 +78,19 @@ theorem eqRec_eq_cast {α : Sort _} {a : α} {motive : (a' : α) → a = a' → 
 
 --Porting note: new theorem. More general version of `eqRec_heq`
 theorem eqRec_heq_self {α : Sort _} {a : α} {motive : (a' : α) → a = a' → Sort _}
-    (x : motive a rfl) {a' : α} (e : a = a') :
-    HEq (@Eq.rec α a motive x a' e) x := by
+    (x : motive a rfl) {a' : α} (e : a = a') : @Eq.rec α a motive x a' e ≍ x := by
   subst e; rfl
 
 @[simp]
 theorem eqRec_heq_iff_heq {α : Sort _} {a : α} {motive : (a' : α) → a = a' → Sort _}
     {x : motive a rfl} {a' : α} {e : a = a'} {β : Sort _} {y : β} :
-    HEq (@Eq.rec α a motive x a' e) y ↔ HEq x y := by
+    @Eq.rec α a motive x a' e ≍ y ↔ x ≍ y := by
   subst e; rfl
 
 @[simp]
 theorem heq_eqRec_iff_heq {α : Sort _} {a : α} {motive : (a' : α) → a = a' → Sort _}
     {x : motive a rfl} {a' : α} {e : a = a'} {β : Sort _} {y : β} :
-    HEq y (@Eq.rec α a motive x a' e) ↔ HEq y x := by
+    y ≍ @Eq.rec α a motive x a' e ↔ y ≍ x := by
   subst e; rfl
 
 /-! ## miscellaneous -/

--- a/Batteries/Tactic/Congr.lean
+++ b/Batteries/Tactic/Congr.lean
@@ -28,7 +28,7 @@ declare_config_elab Congr.elabConfig Congr.Config
 syntax (name := congrConfig) "congr" Parser.Tactic.config (ppSpace num)? : tactic
 
 /--
-Apply congruence (recursively) to goals of the form `⊢ f as = f bs` and `⊢ HEq (f as) (f bs)`.
+Apply congruence (recursively) to goals of the form `⊢ f as = f bs` and `⊢ f as ≍ f bs`.
 * `congr n` controls the depth of the recursive applications.
   This is useful when `congr` is too aggressive in breaking down the goal.
   For example, given `⊢ f (g (x + y)) = f (g (y + x))`,

--- a/BatteriesTest/trans.lean
+++ b/BatteriesTest/trans.lean
@@ -63,7 +63,7 @@ example (x n p : Nat) (h₁ : n * Nat.succ p ≤ x) : n * p ≤ x := by
   · apply Nat.mul_le_mul_left; apply Nat.le_succ
   · apply h₁
 
-example (a : α) (c : γ) : ∀ b : β, HEq a b → HEq b c → HEq a c := by
+example (a : α) (c : γ) : ∀ b : β, a ≍ b → b ≍ c → a ≍ c := by
     intro b h₁ h₂
     trans b
     assumption


### PR DESCRIPTION
The notation `≍` for `HEq` was introduced in leanprover/lean4#8503 and has not yet been included in v4.21.0, but in leanprover/lean4#8872, the core library replaced all instances of `HEq x y` with `x ≍ y`.
This PR applies the same replacement in Batteries.