### PR TITLE
fix `Batteries.Data.String.Lemmas` on nightly-testing

### DIFF
--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -10,10 +10,6 @@ import Batteries.Tactic.Lint.Misc
 import Batteries.Tactic.SeqFocus
 import Std.Classes.Ord.String -- Not needed here, but imported to ensure instance names don't clash.
 
-
--- Commented out temporarily as this is broken on nightly-2025-07-22
-/-
-
 namespace String
 
 -- TODO(kmill): add `@[ext]` attribute to `String.ext` in core.
@@ -1093,5 +1089,3 @@ theorem dropWhile_eq (p : Char → Bool) (s : String) : s.dropWhile p = ⟨s.1.d
     (s.dropWhile p).1 = s.1.dropWhile p := by rw [dropWhile_eq]
 
 end String
-
--/

--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -224,22 +224,20 @@ theorem utf8PrevAux_of_valid {cs cs' : List Char} {c : Char} {i p : Nat}
     simp only [utf8PrevAux, List.cons_append, utf8Len_cons, ← hp]
     rw [if_neg]
     case hnc =>
-      simp only [Pos.ext_iff]
-      rw [Nat.add_right_comm, Nat.add_left_comm]
-      apply ne_add_utf8Size_add_self
+      simp only [Pos.le_iff, pos_add_char]
+      grind [Char.utf8Size_pos]
     refine (utf8PrevAux_of_valid (by simp [Nat.add_assoc, Nat.add_left_comm])).trans ?_
     simp [Nat.add_assoc, Nat.add_comm]
 
 theorem prev_of_valid (cs : List Char) (c : Char) (cs' : List Char) :
     prev ⟨cs ++ c :: cs'⟩ ⟨utf8Len cs + c.utf8Size⟩ = ⟨utf8Len cs⟩ := by
   simp only [prev]
-  refine (if_neg (Pos.ne_of_gt add_utf8Size_pos)).trans ?_
   rw [utf8PrevAux_of_valid] <;> simp
 
 theorem prev_of_valid' (cs cs' : List Char) :
     prev ⟨cs ++ cs'⟩ ⟨utf8Len cs⟩ = ⟨utf8Len cs.dropLast⟩ := by
   match cs, cs.eq_nil_or_concat with
-  | _, .inl rfl => rfl
+  | _, .inl rfl => apply prev_zero
   | _, .inr ⟨cs, c, rfl⟩ => simp [prev_of_valid]
 
 theorem front_eq (s : String) : front s = s.1.headD default := by


### PR DESCRIPTION
Fixes the breakage due to changing the definition of `String.prev`.