### PR TITLE
feat: add `open_problem` syntax variant of `proof_wanted`

### DIFF
--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -11,10 +11,15 @@ open Lean Parser Elab Command
 
 /-- This proof would be a welcome contribution to the library!
 
-The syntax of `proof_wanted` declarations is just like that of `theorem`, but without `:=` or the
-proof. Lean checks that `proof_wanted` declarations are well-formed (e.g. it ensures that all the
-mentioned names are in scope, and that the theorem statement is a valid proposition), but they are
-discarded afterwards. This means that they cannot be used as axioms.
+The syntax of `proof_wanted` (or `open_problem`) declarations is just like that of `theorem`, but
+without `:=` or the proof. Lean checks that these declarations are well-formed (e.g. it ensures that
+all the mentioned names are in scope, and that the theorem statement is a valid proposition), but
+they are discarded afterwards. This means that they cannot be used as axioms.
+
+The `open_problem` syntax variant exists to be able to distinguish between theorems and conjectures,
+i.e. between statements we (informally) know to be true but haven't proven in Lean yet, and
+statements for which we don't (informally) know if they are true. There is no difference to Lean in
+semantics.
 
 Typical usage:
 ```
@@ -24,13 +29,15 @@ Typical usage:
 -/
 @[command_parser]
 def «proof_wanted» := leading_parser
-  declModifiers false >> "proof_wanted" >> declId >> ppIndent declSig
+  declModifiers false >> ("proof_wanted" <|> "open_problem") >> declId >> ppIndent declSig
 
 /-- Elaborate a `proof_wanted` declaration. The declaration is translated to an axiom during
 elaboration, but it's then removed from the environment.
 -/
 @[command_elab «proof_wanted»]
 def elabProofWanted : CommandElab
+  /- We don't need another branch for the `open_problem` variant, as lean (as of 4.22.0-rc4) doesn't
+    check token atoms match when matching with syntax quotations. -/
   | `($mods:declModifiers proof_wanted $name $args* : $res) => withoutModifyingEnv do
     -- The helper axiom is used instead of `sorry` to avoid spurious warnings
     elabCommand <| ← `(

--- a/BatteriesTest/proof_wanted.lean
+++ b/BatteriesTest/proof_wanted.lean
@@ -5,6 +5,9 @@ No unused variable warnings.
 -/
 #guard_msgs in proof_wanted foo (x : Nat) : True
 
+#guard_msgs in open_problem foo (x : Nat) : True
+
+
 /-!
 When not a proposition, rely on `theorem` command failing.
 -/
@@ -13,3 +16,9 @@ error: type of theorem 'foo' is not a proposition
   Nat → Nat
 -/
 #guard_msgs in proof_wanted foo (x : Nat) : Nat
+
+/--
+error: type of theorem 'foo' is not a proposition
+  Nat → Nat
+-/
+#guard_msgs in open_problem foo (x : Nat) : Nat


### PR DESCRIPTION
As discussed [here](https://leanprover.zulipchat.com/#narrow/channel/217875-Is-there-code-for-X.3F/topic/Documenting.20open.20problems) on zulip, it can be useful to be able to distinguish syntactically between problems to which no solution is known vs to which a solution is known, but hasn't been formalized yet. This new syntax (which is semantically the same as the `proof_wanted` syntax) allows to make this distinction.