### PR TITLE
chore: propose deprecation of List.fillNones

### DIFF
--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -829,7 +829,8 @@ dropped from `xs`.
 fillNones [none, some 1, none, none] [2, 3] = [2, 1, 3]
 ```
 -/
-@[simp, deprecated "Deprecated without replacement." (since := "2025-08-07")] def fillNones {α} : List (Option α) → List α → List α
+@[simp, deprecated "Deprecated without replacement." (since := "2025-08-07")]
+def fillNones {α} : List (Option α) → List α → List α
   | [], _ => []
   | some a :: as, as' => a :: fillNones as as'
   | none :: as, [] => as.reduceOption
@@ -837,7 +838,8 @@ fillNones [none, some 1, none, none] [2, 3] = [2, 1, 3]
 
 set_option linter.deprecated false in
 /-- Tail-recursive version of `fillNones`. -/
-@[inline, deprecated "Deprecated without replacement." (since := "2025-08-07")] def fillNonesTR (as : List (Option α)) (as' : List α) : List α := go as as' #[] where
+@[inline, deprecated "Deprecated without replacement." (since := "2025-08-07")]
+def fillNonesTR (as : List (Option α)) (as' : List α) : List α := go as as' #[] where
   /-- Auxiliary for `fillNonesTR`: `fillNonesTR.go as as' acc = acc.toList ++ fillNones as as'`. -/
   go : List (Option α) → List α → Array α → List α
   | [], _, acc => acc.toList
@@ -846,7 +848,8 @@ set_option linter.deprecated false in
   | none :: as, a :: as', acc => go as as' (acc.push a)
 
 set_option linter.deprecated false in
-@[csimp, deprecated "Deprecated without replacement." (since := "2025-08-07")] theorem fillNones_eq_fillNonesTR : @fillNones = @fillNonesTR := by
+@[csimp, deprecated "Deprecated without replacement." (since := "2025-08-07")]
+theorem fillNones_eq_fillNonesTR : @fillNones = @fillNonesTR := by
   funext α as as'; simp [fillNonesTR]
   let rec go (acc) : ∀ as as', @fillNonesTR.go α as as' acc = acc.toList ++ as.fillNones as'
   | [], _ => by simp [fillNonesTR.go]

--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -829,14 +829,15 @@ dropped from `xs`.
 fillNones [none, some 1, none, none] [2, 3] = [2, 1, 3]
 ```
 -/
-@[simp] def fillNones {α} : List (Option α) → List α → List α
+@[simp, deprecated "Deprecated without replacement." (since := "2025-08-07")] def fillNones {α} : List (Option α) → List α → List α
   | [], _ => []
   | some a :: as, as' => a :: fillNones as as'
   | none :: as, [] => as.reduceOption
   | none :: as, a :: as' => a :: fillNones as as'
 
+set_option linter.deprecated false in
 /-- Tail-recursive version of `fillNones`. -/
-@[inline] def fillNonesTR (as : List (Option α)) (as' : List α) : List α := go as as' #[] where
+@[inline, deprecated "Deprecated without replacement." (since := "2025-08-07")] def fillNonesTR (as : List (Option α)) (as' : List α) : List α := go as as' #[] where
   /-- Auxiliary for `fillNonesTR`: `fillNonesTR.go as as' acc = acc.toList ++ fillNones as as'`. -/
   go : List (Option α) → List α → Array α → List α
   | [], _, acc => acc.toList
@@ -844,7 +845,8 @@ fillNones [none, some 1, none, none] [2, 3] = [2, 1, 3]
   | none :: as, [], acc => filterMapTR.go id as acc
   | none :: as, a :: as', acc => go as as' (acc.push a)
 
-@[csimp] theorem fillNones_eq_fillNonesTR : @fillNones = @fillNonesTR := by
+set_option linter.deprecated false in
+@[csimp, deprecated "Deprecated without replacement." (since := "2025-08-07")] theorem fillNones_eq_fillNonesTR : @fillNones = @fillNonesTR := by
   funext α as as'; simp [fillNonesTR]
   let rec go (acc) : ∀ as as', @fillNonesTR.go α as as' acc = acc.toList ++ as.fillNones as'
   | [], _ => by simp [fillNonesTR.go]


### PR DESCRIPTION
Has this ever been used? Is it common in other languages' List APIs? It's just cost me half an hour and I'd love to avoid having it cost me more!

Anyone wanting to keep this function could please assist by reverting 0de31883 on the nightly-testing branch, and then removing the reliance on the now private `filterMapTR.go`. (I'm alternatively happy to review a PR refactoring the relevant code in Lean to make that non-private, by making it a top-level declaration. But either this PR or that needs to happen before the next release.)