### PR TITLE
remove `Std` imports that are now in `Init`

### DIFF
--- a/Batteries/Data/Char/AsciiCasing.lean
+++ b/Batteries/Data/Char/AsciiCasing.lean
@@ -5,7 +5,6 @@ Authors: François G. Dorais
 -/
 import Batteries.Data.Char.Basic
 import Batteries.Tactic.Basic
-import Std.Classes.Ord.String
 
 /-! # Lemmas for ASCII-casing
 

--- a/Batteries/Data/String/Lemmas.lean
+++ b/Batteries/Data/String/Lemmas.lean
@@ -8,7 +8,6 @@ import Batteries.Tactic.Lint.Misc
 import Batteries.Tactic.SeqFocus
 import Batteries.Classes.Order
 import Batteries.Data.List.Basic
-import Std.Classes.Ord.String -- adds import only to avoid instance name collisions
 
 namespace String
 


### PR DESCRIPTION
`Std.Classes.Ord.String` has been moved to `Init.Data.Ord.String`, so we need to remove two obsolete imports.