### PR TITLE
feat: more support for `AlternativeMonad`

### DIFF
--- a/Batteries/Control/Nondet/Basic.lean
+++ b/Batteries/Control/Nondet/Basic.lean
@@ -50,8 +50,10 @@ structure Nondet (m : Type → Type) [MonadBacktrack σ m] (α : Type) : Type wh
   toMLList : MLList m (α × σ)
 
 namespace Nondet
+variable {m : Type → Type}
 
-variable {m : Type → Type} [Monad m] [MonadBacktrack σ m]
+section Monad
+variable [Monad m] [MonadBacktrack σ m]
 
 /-- The empty nondeterministic value. -/
 def nil : Nondet m α := .mk .nil
@@ -87,13 +89,10 @@ def singletonM (x : m α) : Nondet m α :=
 /-- Convert a value to the singleton nondeterministic value. -/
 def singleton (x : α) : Nondet m α := singletonM (pure x)
 
-/-- `Nondet m` is a monad. -/
-instance : Monad (Nondet m) where
+/-- `Nondet m` is an alternative monad. -/
+instance : AlternativeMonad (Nondet m) where
   pure a := singletonM (pure a)
   bind := bind
-
-/-- `Nondet m` is an alternative monad. -/
-instance : Alternative (Nondet m) where
   failure := .nil
   orElse x y := .mk <| x.toMLList.append fun _ => (y ()).toMLList
 
@@ -165,21 +164,6 @@ partial def iterate (f : α → Nondet m α) (a : α) : Nondet m α :=
   singleton a <|> (f a).bind (iterate f)
 
 /--
-Find the first alternative in a nondeterministic value, as a monadic value.
--/
-def head [Alternative m] (L : Nondet m α) : m α := do
-  let (x, s) ← L.toMLList.head
-  restoreState s
-  return x
-
-/--
-Find the value of a monadic function on the first alternative in a nondeterministic value
-where the function succeeds.
--/
-def firstM [Alternative m] (L : Nondet m α) (f : α → m (Option β)) : m β :=
-  L.filterMapM f |>.head
-
-/--
 Convert a non-deterministic value into a lazy list, by discarding the backtrackable state.
 -/
 def toMLList' (L : Nondet m α) : MLList m α := L.toMLList.map (·.1)
@@ -193,6 +177,28 @@ def toList (L : Nondet m α) : m (List (α × σ)) := L.toMLList.force
 Convert a non-deterministic value into a list in the monad, by discarding the backtrackable state.
 -/
 def toList' (L : Nondet m α) : m (List α) := L.toMLList.map (·.1) |>.force
+
+end Monad
+
+section AlternativeMonad
+variable [AlternativeMonad m] [MonadBacktrack σ m]
+
+/--
+Find the first alternative in a nondeterministic value, as a monadic value.
+-/
+def head (L : Nondet m α) : m α := do
+  let (x, s) ← L.toMLList.head
+  restoreState s
+  return x
+
+/--
+Find the value of a monadic function on the first alternative in a nondeterministic value
+where the function succeeds.
+-/
+def firstM (L : Nondet m α) (f : α → m (Option β)) : m β :=
+  L.filterMapM f |>.head
+
+end AlternativeMonad
 
 end Nondet
 

--- a/Batteries/Data/MLList/Basic.lean
+++ b/Batteries/Data/MLList/Basic.lean
@@ -3,6 +3,7 @@ Copyright (c) 2018 Kim Morrison. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Keeley Hoek, Simon Hudon, Kim Morrison
 -/
+import Batteries.Control.AlternativeMonad
 
 /-! # Monadic lazy lists.
 
@@ -448,7 +449,7 @@ partial def fold [Monad m] (f : β → α → β) (init : β) (L : MLList m α) 
 Return the head of a monadic lazy list, as a value in the monad.
 Fails if the list is empty.
 -/
-def head [Monad m] [Alternative m] (L : MLList m α) : m α := do
+def head [AlternativeMonad m] (L : MLList m α) : m α := do
   let some (r, _) ← L.uncons | failure
   return r
 
@@ -456,18 +457,16 @@ def head [Monad m] [Alternative m] (L : MLList m α) : m α := do
 Apply a function returning values inside the monad to a monadic lazy list,
 returning only the first successful result.
 -/
-def firstM [Monad m] [Alternative m] (L : MLList m α) (f : α → m (Option β)) : m β :=
+def firstM [AlternativeMonad m] (L : MLList m α) (f : α → m (Option β)) : m β :=
   (L.filterMapM f).head
 
 /-- Return the first value on which a predicate returns true. -/
-def first [Monad m] [Alternative m] (L : MLList m α) (p : α → Bool) : m α := (L.filter p).head
+def first [AlternativeMonad m] (L : MLList m α) (p : α → Bool) : m α := (L.filter p).head
 
-instance [Monad m] : Monad (MLList m) where
+instance [Monad m] : AlternativeMonad (MLList m) where
   pure a := cons a nil
   map := map
   bind := bind
-
-instance [Monad m] : Alternative (MLList m) where
   failure := nil
   orElse := MLList.append
 

--- a/Batteries/Lean/Meta/Basic.lean
+++ b/Batteries/Lean/Meta/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Mario Carneiro, Jannis Limperg
 -/
 import Lean.Meta.Tactic.Intro
+import Batteries.Control.AlternativeMonad
 
 open Lean Lean.Meta
 
@@ -18,6 +19,7 @@ def Meta.sortFVarsByContextOrder [Monad m] [MonadLCtx m]
     (hyps : Array FVarId) : m (Array FVarId) :=
   return (← getLCtx).sortFVarsByContextOrder hyps
 
+instance : AlternativeMonad Lean.Meta.MetaM where
 
 namespace MetavarContext
 

--- a/BatteriesTest/nondet.lean
+++ b/BatteriesTest/nondet.lean
@@ -1,4 +1,5 @@
 import Batteries.Control.Nondet.Basic
+import Batteries.Lean.Meta.Basic
 
 set_option linter.missingDocs false
 
@@ -6,8 +7,7 @@ open Lean Meta
 
 def M := StateT (List Nat) MetaM
 
-deriving instance Monad for M
-deriving instance Alternative for M
+deriving instance AlternativeMonad for M
 
 instance : MonadBacktrack (List Nat) M where
   saveState := StateT.get
@@ -16,7 +16,7 @@ instance : MonadBacktrack (List Nat) M where
 def record (n : Nat) : M Unit := do
   discard <| restoreState (n :: (← saveState))
 
-def iotaM [Monad m] [Alternative m] [MonadBacktrack σ m] (n : Nat) : Nondet m Nat :=
+def iotaM [AlternativeMonad m] [MonadBacktrack σ m] (n : Nat) : Nondet m Nat :=
   Nondet.ofList (List.range' 1 n).reverse
 
 /-- info: (52, []) -/


### PR DESCRIPTION
This adds instances for `MLLists` and `Nondet`, and fixes definitions that assumed two unrelated monad instances.