### PR TITLE
refactor: define List.IsChain, deprecate Chain and Chain'

### DIFF
--- a/Batteries/Data/List/Basic.lean
+++ b/Batteries/Data/List/Basic.lean
@@ -555,29 +555,54 @@ pwFilter (·<·) [0, 1, 5, 2, 6, 3, 4] = [0, 1, 2, 3, 4]
 def pwFilter (R : α → α → Prop) [DecidableRel R] (l : List α) : List α :=
   l.foldr (fun x IH => if ∀ y ∈ IH, R x y then x :: IH else IH) []
 
-section Chain
+section IsChain
 
-variable (R : α → α → Prop)
+/-- `IsChain R l` means that `R` holds between adjacent elements of `l`.
+```
+IsChain R [a, b, c, d] ↔ R a b ∧ R b c ∧ R c d
+``` -/
+inductive IsChain (R : α → α → Prop) : List α → Prop where
+  /-- A list of length 0 is a chain. -/
+  | nil : IsChain R []
+  /-- A list of length 1 is a chain. -/
+  | singleton (a : α) : IsChain R [a]
+  /-- If `a` relates to `b` and `b::l` is a chain, then `a :: b :: l` is also a chain. -/
+  | cons₂ (hr : R a b) (h : IsChain R (b :: l)) : IsChain R (a :: b :: l)
+
+
+variable {R : α → α → Prop}
+
+attribute [simp, grind ←] IsChain.nil
+attribute [simp, grind ←] IsChain.singleton
+
+@[simp, grind =] theorem isChain_cons₂ : IsChain R (a :: b :: l) ↔ R a b ∧ IsChain R (b :: l) :=
+  ⟨fun | .cons₂ hr h => ⟨hr, h⟩, fun ⟨hr, h⟩ => .cons₂ hr h⟩
+
+instance instDecidableIsChain [h : DecidableRel R] (l : List α) : Decidable (l.IsChain R) :=
+  match l with
+  | [] => isTrue .nil
+  | a :: l => go a l
+  where
+    go (a : α) (l : List α) : Decidable ((a :: l).IsChain R) :=
+      match l with
+      | [] => isTrue <| .singleton a
+      | b :: l => haveI := (go b l); decidable_of_iff'  _ isChain_cons₂
 
 /-- `Chain R a l` means that `R` holds between adjacent elements of `a::l`.
 ```
 Chain R a [b, c, d] ↔ R a b ∧ R b c ∧ R c d
 ``` -/
-inductive Chain : α → List α → Prop
-  /-- A chain of length 1 is trivially a chain. -/
-  | nil {a : α} : Chain a []
-  /-- If `a` relates to `b` and `b::l` is a chain, then `a :: b :: l` is also a chain. -/
-  | cons : ∀ {a b : α} {l : List α}, R a b → Chain b l → Chain a (b :: l)
+@[deprecated IsChain (since := "2025-09-19")]
+def Chain : (α → α → Prop) → α → List α → Prop := (IsChain · <| · :: ·)
 
 /-- `Chain' R l` means that `R` holds between adjacent elements of `l`.
 ```
 Chain' R [a, b, c, d] ↔ R a b ∧ R b c ∧ R c d
 ``` -/
-def Chain' : List α → Prop
-  | [] => True
-  | a :: l => Chain R a l
+@[deprecated IsChain (since := "2025-09-19")]
+def Chain' : (α → α → Prop) → List α → Prop := (IsChain · ·)
 
-end Chain
+end IsChain
 
 /-- `eraseDup l` removes duplicates from `l` (taking only the first occurrence).
 Defined as `pwFilter (≠)`.

--- a/Batteries/Data/List/Lemmas.lean
+++ b/Batteries/Data/List/Lemmas.lean
@@ -330,43 +330,91 @@ theorem disjoint_take_drop : ∀ {l : List α}, l.Nodup → m ≤ n → Disjoint
       refine ⟨fun h => h₀ _ (mem_of_mem_drop h) rfl, ?_⟩
       exact disjoint_take_drop h₁ (Nat.le_of_succ_le_succ h)
 
-/-! ### Chain -/
+/-! ### Pairwise -/
 
-attribute [simp, grind ←] Chain.nil
+attribute [simp, grind ←] Pairwise.nil
 
-@[simp, grind =]
-theorem chain_cons {a b : α} {l : List α} : Chain R a (b :: l) ↔ R a b ∧ Chain R b l :=
-  ⟨fun p => by cases p with | cons n p => exact ⟨n, p⟩,
-   fun ⟨n, p⟩ => p.cons n⟩
+protected theorem Pairwise.isChain (p : Pairwise R l) : IsChain R l := by
+  induction p with
+  | nil => grind
+  | cons _ l => cases l with grind
 
-theorem rel_of_chain_cons {a b : α} {l : List α} (p : Chain R a (b :: l)) : R a b :=
-  (chain_cons.1 p).1
+/-! ### IsChain -/
 
-theorem chain_of_chain_cons {a b : α} {l : List α} (p : Chain R a (b :: l)) : Chain R b l :=
-  (chain_cons.1 p).2
+attribute [simp, grind ←] IsChain.nil
+attribute [simp, grind ←] IsChain.singleton
 
-theorem Chain.imp' {R S : α → α → Prop} (HRS : ∀ ⦃a b⦄, R a b → S a b) {a b : α}
-    (Hab : ∀ ⦃c⦄, R a c → S b c) {l : List α} (p : Chain R a l) : Chain S b l := by
-  induction p generalizing b with grind
+@[deprecated (since := "2025-09-19")]
+alias chain_cons := isChain_cons₂
 
-theorem Chain.imp {R S : α → α → Prop} (H : ∀ a b, R a b → S a b) {a : α} {l : List α}
-    (p : Chain R a l) : Chain S a l :=
-  p.imp' H (H a)
+theorem rel_of_isChain_cons₂ {a b : α} {l : List α} (p : IsChain R (a :: b :: l)) : R a b :=
+  (isChain_cons₂.1 p).1
 
-protected theorem Pairwise.chain (p : Pairwise R (a :: l)) : Chain R a l := by
-  let ⟨r, p'⟩ := pairwise_cons.1 p; clear p
-  induction p' generalizing a with grind
+@[deprecated (since := "2025-09-19")]
+alias rel_of_chain_cons := rel_of_isChain_cons₂
+
+theorem isChain_of_isChain_cons₂ {a b : α} {l : List α} (p : IsChain R (a :: b :: l)) :
+    IsChain R (b :: l) := (isChain_cons₂.1 p).2
+
+@[deprecated (since := "2025-09-19")]
+alias chain_of_chain_cons := isChain_of_isChain_cons₂
+
+@[grind]
+theorem IsChain.imp {S : α → α → Prop} (H : ∀ ⦃a b⦄, R a b → S a b) {l : List α} (p : IsChain R l) :
+    IsChain S l := by induction p with grind
+
+theorem IsChain.imp' {S : α → α → Prop} (HRS : ∀ ⦃a b⦄, R a b → S a b)
+    (Hab : ∀ ⦃c⦄, R a c → S b c) {l : List α} : IsChain R (a :: l) → IsChain S (b :: l) := by
+  cases l with grind
+
+@[deprecated (since := "2025-09-19")]
+alias Chain.imp := IsChain.imp
+
+@[deprecated (since := "2025-09-19")]
+alias Chain.imp' := IsChain.imp'
+
+@[deprecated (since := "2025-09-19")]
+protected alias Pairwise.chain := Pairwise.isChain
+
+protected theorem IsChain.pairwise (ht : ∀ ⦃a b c⦄, R a b → R b c → R a c) (c : IsChain R l) :
+    Pairwise R l := by
+  induction c with
+  | nil | singleton => grind
+  | cons₂ hr h p =>
+    simp at p ⊢
+    exact ⟨⟨hr, fun _ ha => ht hr <| p.1 _ ha⟩, p⟩
+
+theorem isChain_iff_pairwise (ht : ∀ ⦃a b c⦄, R a b → R b c → R a c) :
+    IsChain R l ↔ Pairwise R l := ⟨IsChain.pairwise ht, Pairwise.isChain⟩
+
+theorem isChain_iff_getElem {l : List α} :
+    IsChain R l ↔ ∀ (i : Nat) (_hi : i + 1 < l.length), R l[i] l[i + 1] := by
+  induction l with
+  | nil => grind
+  | cons a l IH => cases l with | nil => grind | cons b l => simp [IH, Nat.forall_lt_succ_left']
+
+theorem IsChain.getElem {l : List α} (c : IsChain R l) (i : Nat) (hi : i + 1 < l.length) :
+    R l[i] l[i + 1] := isChain_iff_getElem.mp c _ _
 
 /-! ### range', range -/
 
-theorem chain_succ_range' : ∀ s n step : Nat,
-    Chain (fun a b => b = a + step) s (range' (s + step) n step)
-  | _, 0, _ => Chain.nil
-  | s, n + 1, step => (chain_succ_range' (s + step) n step).cons rfl
+theorem isChain_range' (s : Nat) : ∀ n step : Nat,
+    IsChain (fun a b => b = a + step) (range' s n step)
+  | 0, _ => .nil
+  | 1, _ => .singleton _
+  | n + 2, step => (isChain_range' (s + step) (n + 1) step).cons₂ rfl
 
+@[deprecated isChain_range' (since := "2025-09-19")]
+theorem chain_succ_range' (s : Nat) (n : Nat) (step: Nat) :
+    IsChain (fun a b => b = a + step) (s :: range' (s + step) n step) := isChain_range'  _ (n + 1) _
+
+theorem isChain_lt_range' (s n : Nat) {step} (h : 0 < step) :
+    IsChain (· < ·) (range' s n step) :=
+  (isChain_range' s n step).imp fun _ _ e => e.symm ▸ Nat.lt_add_of_pos_right h
+
+@[deprecated isChain_lt_range' (since := "2025-09-19")]
 theorem chain_lt_range' (s n : Nat) {step} (h : 0 < step) :
-    Chain (· < ·) s (range' (s + step) n step) :=
-  (chain_succ_range' s n step).imp fun _ _ e => e.symm ▸ Nat.lt_add_of_pos_right h
+    IsChain (· < ·) (s :: range' (s + step) n step) := isChain_lt_range' _ (n + 1) h
 
 /-! ### indexOf and indexesOf -/
 


### PR DESCRIPTION
Will require mathlib update. Deprecates #1052 which now appears to be inactive.