### PR TITLE
fix: Remove proof wanted

### DIFF
--- a/Batteries/Data/Array/Monadic.lean
+++ b/Batteries/Data/Array/Monadic.lean
@@ -127,9 +127,9 @@ theorem SatisfiesM_foldrM [Monad m] [LawfulMonad m]
   · next h => exact .pure (Nat.eq_zero_of_not_pos h ▸ h0)
 
 theorem SatisfiesM_mapFinIdxM [Monad m] [LawfulMonad m] (as : Array α)
-    (f : (i : Nat) → α → (h : i < as.size) → m β)
+    (f : (i : Nat) → α → i < as.size → m β)
     (motive : Nat → Prop) (h0 : motive 0)
-    (p : (i : Nat) → β → (h : i < as.size) → Prop)
+    (p : (i : Nat) → β → i < as.size → Prop)
     (hs : ∀ i h, motive i → SatisfiesM (p i · h ∧ motive (i + 1)) (f i as[i] h)) :
     SatisfiesM
       (fun arr => motive as.size ∧ ∃ eq : arr.size = as.size, ∀ i h, p i arr[i] h)
@@ -151,7 +151,7 @@ theorem SatisfiesM_mapFinIdxM [Monad m] [LawfulMonad m] (as : Array α)
 
 theorem SatisfiesM_mapIdxM [Monad m] [LawfulMonad m] (as : Array α) (f : Nat → α → m β)
     (motive : Nat → Prop) (h0 : motive 0)
-    (p : (i : Nat) → β → (h : i < as.size) → Prop)
+    (p : (i : Nat) → β → i < as.size → Prop)
     (hs : ∀ i h, motive i → SatisfiesM (p i · h ∧ motive (i + 1)) (f i as[i])) :
     SatisfiesM
       (fun arr => motive as.size ∧ ∃ eq : arr.size = as.size, ∀ i h, p i arr[i] h)
@@ -159,7 +159,7 @@ theorem SatisfiesM_mapIdxM [Monad m] [LawfulMonad m] (as : Array α) (f : Nat �
   SatisfiesM_mapFinIdxM as (fun i a _ => f i a) motive h0 p hs
 
 theorem size_mapFinIdxM [Monad m] [LawfulMonad m]
-    (as : Array α) (f : (i : Nat) → α → (h : i < as.size) → m β) :
+    (as : Array α) (f : (i : Nat) → α → i < as.size → m β) :
     SatisfiesM (fun arr => arr.size = as.size) (Array.mapFinIdxM as f) :=
   (SatisfiesM_mapFinIdxM _ _ (fun _ => True) trivial (fun _ _ _ => True)
     (fun _ _ _ => .of_true fun _ => ⟨trivial, trivial⟩)).imp (·.2.1)

--- a/Batteries/Data/Array/Monadic.lean
+++ b/Batteries/Data/Array/Monadic.lean
@@ -60,13 +60,6 @@ theorem size_mapM [Monad m] [LawfulMonad m] (f : α → m β) (as : Array α) :
     SatisfiesM (fun arr => arr.size = as.size) (Array.mapM f as) :=
   (SatisfiesM_mapM' _ _ (fun _ _ => True) (fun _ => .trivial)).imp (·.1)
 
-proof_wanted size_mapIdxM [Monad m] [LawfulMonad m] (as : Array α) (f : Nat → α → m β) :
-    SatisfiesM (fun arr => arr.size = as.size) (Array.mapIdxM f as)
-
-proof_wanted size_mapFinIdxM [Monad m] [LawfulMonad m]
-    (as : Array α) (f : (i : Nat) → α → (h : i < as.size) → m β) :
-    SatisfiesM (fun arr => arr.size = as.size) (Array.mapFinIdxM as f)
-
 theorem SatisfiesM_anyM [Monad m] [LawfulMonad m] (p : α → m Bool) (as : Array α) (start stop)
     (hstart : start ≤ min stop as.size) (tru : Prop) (fal : Nat → Prop) (h0 : fal start)
     (hp : ∀ i : Fin as.size, i.1 < stop → fal i.1 →


### PR DESCRIPTION
We have two proof_wanted statements that appear to have already been completed in batteries#1109. This commit removes them (and makes a minor edit to some hypotheses which don't need to be named).