### PR TITLE
feat: Add `Fin.findSomeRev?` and `Fin.findRev?`

### DIFF
--- a/Batteries/Data/Fin/Basic.lean
+++ b/Batteries/Data/Fin/Basic.lean
@@ -96,3 +96,17 @@ The function `p` is not evaluated on further inputs after the first `i` is found
 -/
 @[inline] def find? (p : Fin n → Bool) : Option (Fin n) :=
   findSome? <| Option.guard fun i => p i
+
+/--
+`findSomeRev? f` returns `f i` for the last `i` for which `f i` is `some _`, or `none` if no such
+element is found. The function `f` is not evaluated on further inputs after the first `i` is found.
+-/
+@[inline] def findSomeRev? (f : Fin n → Option α) : Option α :=
+  foldr n (fun i r => r <|> f i) none
+
+/--
+`find? p` returns the first `i` for which `p i = true`, or `none` if no such element is found.
+The function `p` is not evaluated on further inputs after the first `i` is found.
+-/
+@[inline] def findRev? (p : Fin n → Bool) : Option (Fin n) :=
+  findSomeRev? <| Option.guard fun i => p i

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -83,20 +83,18 @@ theorem findSome?_eq_some_iff {f : Fin n → Option α} :
   induction n with
   | zero =>
     simp only [findSome?_zero, (Option.some_ne_none _).symm, false_iff]
-    exact fun  ⟨i, _⟩ => i.elim0
+    exact fun ⟨i, _⟩ => i.elim0
   | succ n ih =>
-    simp only [findSome?_succ, Option.or_eq_some_iff, Fin.exists_fin_succ, Fin.forall_fin_succ,
-      not_lt_zero, false_implies, implies_true, and_true, succ_lt_succ_iff, succ_pos,
-      forall_const, ih, and_left_comm (b := f 0 = none), exists_and_left]
+    simp only [findSome?_succ, Option.or_eq_some_iff, exists_fin_succ, forall_fin_succ,
+      succ_lt_succ_iff, succ_pos, not_lt_zero, ih]
+    grind
 
 @[simp, grind =] theorem findSome?_eq_none_iff {f : Fin n → Option α} :
     findSome? f = none ↔ ∀ i, f i = none := by
   induction n with
   | zero =>
-    simp only [findSome?_zero, true_iff]
-    exact fun i => i.elim0
-  | succ n ih =>
-    simp only [findSome?_succ, Option.or_eq_none_iff, ih, forall_fin_succ]
+    simp only [findSome?_zero, true_iff]; exact fun i => i.elim0
+  | succ n ih => simp only [findSome?_succ, Option.or_eq_none_iff, ih, forall_fin_succ]
 
 theorem isNone_findSome?_iff {f : Fin n → Option α} :
     (findSome? f).isNone ↔ ∀ i, (f i).isNone := by simp

--- a/Batteries/Data/Fin/Lemmas.lean
+++ b/Batteries/Data/Fin/Lemmas.lean
@@ -147,7 +147,7 @@ theorem findSome?_eq_findSome?_finRange (f : Fin n → Option α) :
     rw [findSome?_succ, List.finRange_succ, List.findSome?_cons]
     cases f 0 <;> simp [ih, List.findSome?_map, Function.comp_def]
 
-/-! ### Fin.find? -/
+/-! ### find? -/
 
 @[simp] theorem find?_zero {p : Fin 0 → Bool} : find? p = none := rfl
 
@@ -204,11 +204,8 @@ theorem get_find?_minimal {p : Fin n → Bool}  (h : (find? p).isSome) :
 theorem find?_eq_find?_finRange {p : Fin n → Bool} : find? p = (List.finRange n).find? p :=
   (findSome?_eq_findSome?_finRange _).trans (List.findSome?_guard)
 
-/-! ### exists -/
-
 theorem exists_eq_true_iff_exists_minimal_eq_true (p : Fin n → Bool):
-    (∃ i, p i) ↔ ∃ i, p i ∧ ∀ j < i, p j = false := by
-  cases h : find? p <;> grind
+    (∃ i, p i) ↔ ∃ i, p i ∧ ∀ j < i, p j = false := by cases h : find? p <;> grind
 
 theorem exists_iff_exists_minimal (p : Fin n → Prop) [DecidablePred p] :
     (∃ i, p i) ↔ ∃ i, p i ∧ ∀ j < i, ¬ p j := by


### PR DESCRIPTION
`Fin.findSomeRev?` and `Fin.findRev?`are obvious functions with a real, practical meaning which we do not have. This adds them.

This should not affect Mathlib except that there is some minor deprecation to do.