### PR TITLE
feat: prove/improve proof of [take,drop,splitAt,getElem?,getElem]_flatten

### DIFF
--- a/Batteries/Data/List/Scan.lean
+++ b/Batteries/Data/List/Scan.lean
@@ -233,7 +233,7 @@ theorem getElem_flatten (L : List (List α)) (i : Nat) (h : i < L.flatten.length
         · simp
 
 /--
-Lemma for `take_flatten`.
+Lemma for `splitAt_flatten`.
 Moving the threshold and all elements of `L` upwards by `offset`
 does not change the result of `findIdx`.
 -/
@@ -253,28 +253,35 @@ theorem findIdx_thres_offset (L : List Nat) (offset thres : Nat) :
       apply tail_ih
 
 /--
-Taking the first `i` elements of a flattened list
-can be expressed as the flattening of the first `j` complete sublists, plus the first
-`k` elements of the `j`-th sublist.
+Splitting a flattened list at `i` gives the two parts:
+- The flattening of the first `j` complete sublists, plus the first `k` elements of
+  the `j`-th sublist, and
+- The `j`-th sublist with its first `k` elements removed, plus the flattening of
+  the original list with the first `j+1` sublists removed.
 
 The indices are computed as:
 - `j` is one less than where the cumulative sum first exceeds `i`
 - `k` is `i` minus the total length of the first `j` sublists
 -/
-theorem take_flatten (L : List (List α)) (i : Nat) :
-    let j := (L.map length).partialSums.findIdx (· > i) - 1
+theorem splitAt_flatten (L : List (List α)) (i : Nat) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
     let k := i - (L.take j).flatten.length
-    L.flatten.take i = (L.take j).flatten ++ (L[j]?.getD []).take k := by
+    L.flatten.splitAt i = (
+      (L.take j).flatten ++ (L[j]?.getD []).take k,
+      (L[j]?.getD []).drop k ++ (L.drop (j + 1)).flatten
+    ) := by
+  rw [splitAt_eq, Prod.mk.injEq]
   induction L generalizing i with
   | nil =>
     simp
   | cons head tail tail_ih =>
-    have not_zero_gt_i : decide (0 > i) = false := by simp
     rw [map_cons, partialSums_cons, findIdx_cons]
     by_cases i_head_length : i < head.length
     · rw [partialSums_unfold_once, map_cons, findIdx_cons]
       simp [i_head_length]
-      rw [take_append_of_le_length (by lia)]
+      constructor
+      · rw [take_append_of_le_length (by lia)]
+      · rw [drop_append_of_le_length (by lia)]
     · have i_ge_head_length := Nat.le_of_not_lt i_head_length
       -- handle j in both the goal and tail_ih to extract common term
       have ⟨goalJ, goalJ_def⟩ : ∃ j, j =
@@ -288,43 +295,32 @@ theorem take_flatten (L : List (List α)) (i : Nat) :
       simp [findIdx_cons, i_head_length] at goalJ_def
       have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
       -- now with this information, the goal is essentially the same as tail_ih
-      simpa [goalJ_succ, take_append, take_of_length_le i_ge_head_length,
-        ← Nat.sub_sub] using tail_ih
+      constructor
+      · simpa [goalJ_succ, take_append,
+          take_of_length_le i_ge_head_length, ← Nat.sub_sub]
+          using tail_ih.1
+      · simpa [goalJ_succ, drop_append,
+          drop_of_length_le i_ge_head_length, ← Nat.sub_sub]
+          using tail_ih.2
 
 /--
-Companion theorem of `take_flatten`: Dropping the first `i` elements of a flattened list
-can be expressed as the `j`-th sublist without its first `k` elements, plus the
-flattening of the sublists without the first `j+1` of them.
+Taking the first `i` elements of a flattened list
+can be expressed as the flattening of the first `j` complete sublists, plus the first
+`k` elements of the `j`-th sublist.
+-/
+theorem take_flatten (L : List (List α)) (i : Nat) :
+    let j := (L.map length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    L.flatten.take i = (L.take j).flatten ++ (L[j]?.getD []).take k := by
+  grind [splitAt_flatten L i]
 
-The indices are computed as:
-- `j` is one less than where the cumulative sum first exceeds `i`
-- `k` is `i` minus the total length of the first `j` sublists
+/--
+Dropping the first `i` elements of a flattened list
+can be expressed as the `j`-th sublist without its first `k` elements, plus
+the flattening of the original list with the first `j+1` sublists removed.
 -/
 theorem drop_flatten (L : List (List α)) (i : Nat) :
     let j := (L.map List.length).partialSums.findIdx (· > i) - 1
     let k := i - (L.take j).flatten.length
     L.flatten.drop i = (L[j]?.getD []).drop k ++ (L.drop (j + 1)).flatten := by
-  induction L generalizing i with
-  | nil =>
-    simp
-  | cons head tail tail_ih =>
-    have not_zero_gt_i : decide (0 > i) = false := by simp
-    rw [map_cons, partialSums_cons, findIdx_cons]
-    by_cases i_head_length : i < head.length
-    · rw [partialSums_unfold_once, map_cons, findIdx_cons]
-      simp [i_head_length]
-      rw [drop_append_of_le_length (by lia)]
-    · have i_ge_head_length := Nat.le_of_not_lt i_head_length
-      have ⟨goalJ, goalJ_def⟩ : ∃ j, j =
-        ((tail.map length).partialSums.map (head.length + ·)).findIdx (· > i) := by simp
-      rw [← goalJ_def]
-      specialize tail_ih (i - head.length)
-      rw [findIdx_thres_offset _ head.length, Nat.sub_add_cancel i_ge_head_length] at tail_ih
-      rw [← goalJ_def] at tail_ih
-      -- goalJ is succ
-      rw [partialSums_unfold_once] at goalJ_def
-      simp [findIdx_cons, i_head_length] at goalJ_def
-      have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
-      -- now with this information, the goal is essentially the same as tail_ih
-      simpa [goalJ_succ, drop_append, drop_of_length_le i_ge_head_length,
-        ← Nat.sub_sub] using tail_ih
+  grind [splitAt_flatten L i]

--- a/Batteries/Data/List/Scan.lean
+++ b/Batteries/Data/List/Scan.lean
@@ -20,6 +20,15 @@ Prove basic results about `List.scanl`, `List.scanr`, `List.scanlM` and `List.sc
 
 namespace List
 
+/-! ### scanl -/
+
+/--
+Unfold `scanl` once, unconditionally exposing its head.
+-/
+theorem scanl_unfold_once {f : β → α → β} {init : β} {as : List α} :
+    as.scanl f init = init :: match as with | [] => [] | a :: as' => as'.scanl f (f init a) := by
+  split <;> simp
+
 /-! ### partialSums/partialProd -/
 
 @[simp, grind =]
@@ -46,6 +55,14 @@ theorem partialSums_cons [Add α] [Zero α] [Std.Associative (α := α) (· + ·
     simp [Std.LawfulLeftIdentity.left_id, Std.LawfulRightIdentity.right_id]
     rw [ih (a := b), ih (a := a + b), map_map]
     congr; funext; simp [Std.Associative.assoc]
+
+/--
+Unfold `partialSums` once, unconditionally exposing its head.
+-/
+theorem partialSums_unfold_once [Add α] [Zero α] [Std.Associative (α := α) (· + ·)]
+    [Std.LawfulIdentity (α := α) (· + ·) 0] {l : List α} :
+    l.partialSums = (0 : α) :: match l with | [] => [] | a :: l' => l'.partialSums.map (a + ·) := by
+  split <;> simp [partialSums_cons]
 
 theorem partialSums_append [Add α] [Zero α] [Std.Associative (α := α) (· + ·)]
     [Std.LawfulIdentity (α := α) (· + ·) 0] {l₁ l₂ : List α} :
@@ -216,6 +233,26 @@ theorem getElem_flatten (L : List (List α)) (i : Nat) (h : i < L.flatten.length
         · simp
 
 /--
+Lemma for `take_flatten`.
+Moving the threshold and all elements of `L` upwards by `offset`
+does not change the result of `findIdx`.
+-/
+theorem findIdx_thres_offset (L : List Nat) (offset thres : Nat) :
+    L.findIdx (· > thres) =
+    (L.map (offset + ·)).findIdx (· > thres + offset) := by
+  induction L generalizing offset thres with
+  | nil =>
+    simp
+  | cons head tail tail_ih =>
+    simp [findIdx_cons]
+    by_cases thres_head : thres < head
+    · grind
+    · have not_thres_offset_lt_offset_head : ¬(thres + offset < offset + head) := by lia
+      simp [thres_head, not_thres_offset_lt_offset_head]
+      simp at tail_ih
+      apply tail_ih
+
+/--
 Taking the first `i` elements of a flattened list
 can be expressed as the flattening of the first `j` complete sublists, plus the first
 `k` elements of the `j`-th sublist.
@@ -224,7 +261,31 @@ The indices are computed as:
 - `j` is one less than where the cumulative sum first exceeds `i`
 - `k` is `i` minus the total length of the first `j` sublists
 -/
-proof_wanted take_flatten (L : List (List α)) (i : Nat) :
+theorem take_flatten (L : List (List α)) (i : Nat) :
     let j := (L.map length).partialSums.findIdx (· > i) - 1
     let k := i - (L.take j).flatten.length
-    L.flatten.take i = (L.take j).flatten ++ (L[j]?.getD []).take k
+    L.flatten.take i = (L.take j).flatten ++ (L[j]?.getD []).take k := by
+  induction L generalizing i with
+  | nil =>
+    simp
+  | cons head tail tail_ih =>
+    have not_zero_gt_i : decide (0 > i) = false := by simp
+    rw [map_cons, partialSums_cons, findIdx_cons]
+    by_cases i_head_length : i < head.length
+    · rw [partialSums_unfold_once, map_cons, findIdx_cons]
+      simp [i_head_length]
+      rw [take_append_of_le_length (by lia)]
+    · have i_ge_head_length := Nat.le_of_not_lt i_head_length
+      -- handle j in both the goal and tail_ih to extract common term
+      have ⟨goalJ, goalJ_def⟩ : ∃ j, j =
+        ((tail.map length).partialSums.map (head.length + ·)).findIdx (· > i) := by simp
+      rw [← goalJ_def]
+      specialize tail_ih (i - head.length)
+      rw [findIdx_thres_offset _ head.length, Nat.sub_add_cancel i_ge_head_length] at tail_ih
+      rw [← goalJ_def] at tail_ih
+      -- goalJ is succ
+      rw [partialSums_unfold_once] at goalJ_def
+      simp [findIdx_cons, i_head_length] at goalJ_def
+      have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
+      -- now with this information, the goal is essentially the same as tail_ih
+      simpa [goalJ_succ, take_append, take_of_length_le i_ge_head_length, ← Nat.sub_sub] using tail_ih

--- a/Batteries/Data/List/Scan.lean
+++ b/Batteries/Data/List/Scan.lean
@@ -237,7 +237,7 @@ Lemma for `take_flatten` and all related theorems.
 Moving the threshold and all elements of `L` upwards by `offset`
 does not change the result of `findIdx`.
 -/
-theorem findIdx_thres_offset (L : List Nat) (offset thres : Nat) :
+private theorem findIdx_thres_offset (L : List Nat) (offset thres : Nat) :
     L.findIdx (· > thres) =
     (L.map (offset + ·)).findIdx (· > thres + offset) := by
   induction L generalizing offset thres with
@@ -248,9 +248,7 @@ theorem findIdx_thres_offset (L : List Nat) (offset thres : Nat) :
     by_cases thres_head : thres < head
     · grind
     · have not_thres_offset_lt_offset_head : ¬(thres + offset < offset + head) := by lia
-      simp [thres_head, not_thres_offset_lt_offset_head]
-      simp at tail_ih
-      apply tail_ih
+      simpa [thres_head, not_thres_offset_lt_offset_head] using tail_ih offset thres
 
 private theorem take_flatten_helper (L : List (List α)) (i : Nat) :
     let j := (L.map List.length).partialSums.findIdx (· > i) - 1

--- a/Batteries/Data/List/Scan.lean
+++ b/Batteries/Data/List/Scan.lean
@@ -233,7 +233,7 @@ theorem getElem_flatten (L : List (List α)) (i : Nat) (h : i < L.flatten.length
         · simp
 
 /--
-Lemma for `splitAt_flatten`.
+Lemma for `take_flatten` and all related theorems.
 Moving the threshold and all elements of `L` upwards by `offset`
 does not change the result of `findIdx`.
 -/
@@ -251,6 +251,61 @@ theorem findIdx_thres_offset (L : List Nat) (offset thres : Nat) :
       simp [thres_head, not_thres_offset_lt_offset_head]
       simp at tail_ih
       apply tail_ih
+
+private theorem take_flatten_helper (L : List (List α)) (i : Nat) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    (i < L.flatten.length → j < L.length) ∧
+    (i < L.flatten.length → (h : j < L.length) → k < L[j].length) ∧
+    L.flatten[i]? = L[j]?.bind (·[k]?) ∧
+    L.flatten.take i = (L.take j).flatten ++ (L[j]?.getD []).take k ∧
+    L.flatten.drop i = (L[j]?.getD []).drop k ++ (L.drop (j + 1)).flatten ∧
+    L.flatten.drop i = (L.drop j).flatten.drop k := by
+  induction L generalizing i with
+  | nil =>
+    simp
+  | cons head tail tail_ih =>
+    rw [map_cons, partialSums_cons, findIdx_cons]
+    by_cases i_head_length : i < head.length
+    · rw [partialSums_unfold_once, map_cons, findIdx_cons]
+      simp [i_head_length]
+      -- inequalities are removed by simp; last two statements are discharged with the same line
+      constructor <;> try constructor
+      · rw [getElem?_append]; simp [i_head_length]
+      · rw [take_append_of_le_length (by lia)]
+      · rw [drop_append_of_le_length (by lia)]
+    · have i_ge_head_length := Nat.le_of_not_lt i_head_length
+      -- handle j in both the goal and tail_ih to extract common term
+      have ⟨goalJ, goalJ_def⟩ : ∃ j, j =
+        ((tail.map length).partialSums.map (head.length + ·)).findIdx (· > i) := by simp
+      rw [← goalJ_def]
+      specialize tail_ih (i - head.length)
+      rw [findIdx_thres_offset _ head.length, Nat.sub_add_cancel i_ge_head_length] at tail_ih
+      rw [← goalJ_def] at tail_ih
+      -- goalJ is succ
+      rw [partialSums_unfold_once] at goalJ_def
+      simp [findIdx_cons, i_head_length] at goalJ_def
+      have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
+      -- now with this information, the goal is essentially the same as tail_ih
+      constructor <;> try constructor <;> try constructor <;> try constructor
+      · simp [goalJ_succ]
+        intro tail_ih_hyp
+        have tail_ih_hyp := Nat.sub_lt_left_of_lt_add (by lia) tail_ih_hyp
+        simp [goalJ_succ] at tail_ih
+        apply tail_ih.1 tail_ih_hyp
+      · simp [goalJ_succ, ← Nat.sub_sub]
+        intro tail_ih_hyp
+        have tail_ih_hyp := Nat.sub_lt_left_of_lt_add (by lia) tail_ih_hyp
+        simp [goalJ_succ] at tail_ih
+        apply tail_ih.2.1 tail_ih_hyp
+      · simpa [goalJ_succ, getElem?_append,
+          i_head_length, ← Nat.sub_sub] using tail_ih.2.2.1
+      · simpa [goalJ_succ, take_append,
+          take_of_length_le i_ge_head_length, ← Nat.sub_sub]
+          using tail_ih.2.2.2.1
+      · simpa [goalJ_succ, drop_append,
+          drop_of_length_le i_ge_head_length, ← Nat.sub_sub]
+          using tail_ih.2.2.2.2
 
 /--
 Splitting a flattened list at `i` gives the two parts:
@@ -271,37 +326,7 @@ theorem splitAt_flatten (L : List (List α)) (i : Nat) :
       (L[j]?.getD []).drop k ++ (L.drop (j + 1)).flatten
     ) := by
   rw [splitAt_eq, Prod.mk.injEq]
-  induction L generalizing i with
-  | nil =>
-    simp
-  | cons head tail tail_ih =>
-    rw [map_cons, partialSums_cons, findIdx_cons]
-    by_cases i_head_length : i < head.length
-    · rw [partialSums_unfold_once, map_cons, findIdx_cons]
-      simp [i_head_length]
-      constructor
-      · rw [take_append_of_le_length (by lia)]
-      · rw [drop_append_of_le_length (by lia)]
-    · have i_ge_head_length := Nat.le_of_not_lt i_head_length
-      -- handle j in both the goal and tail_ih to extract common term
-      have ⟨goalJ, goalJ_def⟩ : ∃ j, j =
-        ((tail.map length).partialSums.map (head.length + ·)).findIdx (· > i) := by simp
-      rw [← goalJ_def]
-      specialize tail_ih (i - head.length)
-      rw [findIdx_thres_offset _ head.length, Nat.sub_add_cancel i_ge_head_length] at tail_ih
-      rw [← goalJ_def] at tail_ih
-      -- goalJ is succ
-      rw [partialSums_unfold_once] at goalJ_def
-      simp [findIdx_cons, i_head_length] at goalJ_def
-      have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
-      -- now with this information, the goal is essentially the same as tail_ih
-      constructor
-      · simpa [goalJ_succ, take_append,
-          take_of_length_le i_ge_head_length, ← Nat.sub_sub]
-          using tail_ih.1
-      · simpa [goalJ_succ, drop_append,
-          drop_of_length_le i_ge_head_length, ← Nat.sub_sub]
-          using tail_ih.2
+  grind [take_flatten_helper L i]
 
 /--
 Taking the first `i` elements of a flattened list
@@ -309,10 +334,10 @@ can be expressed as the flattening of the first `j` complete sublists, plus the 
 `k` elements of the `j`-th sublist.
 -/
 theorem take_flatten (L : List (List α)) (i : Nat) :
-    let j := (L.map length).partialSums.findIdx (· > i) - 1
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
     let k := i - (L.take j).flatten.length
     L.flatten.take i = (L.take j).flatten ++ (L[j]?.getD []).take k := by
-  grind [splitAt_flatten L i]
+  grind [take_flatten_helper L i]
 
 /--
 Dropping the first `i` elements of a flattened list
@@ -323,4 +348,40 @@ theorem drop_flatten (L : List (List α)) (i : Nat) :
     let j := (L.map List.length).partialSums.findIdx (· > i) - 1
     let k := i - (L.take j).flatten.length
     L.flatten.drop i = (L[j]?.getD []).drop k ++ (L.drop (j + 1)).flatten := by
-  grind [splitAt_flatten L i]
+  grind [take_flatten_helper L i]
+
+/--
+Alternatively, dropping the first `i` elements of a flattened list
+can be expressed as removing the first `j` sublists, flattening the result,
+and then removing its first `k` elements.
+-/
+theorem drop_flatten' (L : List (List α)) (i : Nat) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    L.flatten.drop i = (L.drop j).flatten.drop k := by
+  grind [take_flatten_helper L i]
+
+theorem getElem?_flatten (L : List (List α)) (i : Nat) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    L.flatten[i]? = L[j]?.bind (·[k]?) := by
+  grind [take_flatten_helper L i]
+
+theorem getElem_j_valid (L : List (List α)) (i : Nat) (h : i < L.flatten.length) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    j < L.length := by
+  grind [take_flatten_helper L i]
+
+theorem getElem_k_valid (L : List (List α)) (i : Nat) (h : i < L.flatten.length) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    (h' : j < L.length) → k < L[j].length := by
+  grind [take_flatten_helper L i]
+
+theorem getElem_flatten' (L : List (List α)) (i : Nat) (h : i < L.flatten.length) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    have j_valid := getElem_j_valid L i h
+    have k_valid := getElem_k_valid L i h j_valid
+    L.flatten[i] = L[j][k] := by
+  grind [take_flatten_helper L i]

--- a/Batteries/Data/List/Scan.lean
+++ b/Batteries/Data/List/Scan.lean
@@ -290,3 +290,41 @@ theorem take_flatten (L : List (List α)) (i : Nat) :
       -- now with this information, the goal is essentially the same as tail_ih
       simpa [goalJ_succ, take_append, take_of_length_le i_ge_head_length,
         ← Nat.sub_sub] using tail_ih
+
+/--
+Companion theorem of `take_flatten`: Dropping the first `i` elements of a flattened list
+can be expressed as the `j`-th sublist without its first `k` elements, plus the
+flattening of the sublists without the first `j+1` of them.
+
+The indices are computed as:
+- `j` is one less than where the cumulative sum first exceeds `i`
+- `k` is `i` minus the total length of the first `j` sublists
+-/
+theorem drop_flatten (L : List (List α)) (i : Nat) :
+    let j := (L.map List.length).partialSums.findIdx (· > i) - 1
+    let k := i - (L.take j).flatten.length
+    L.flatten.drop i = (L[j]?.getD []).drop k ++ (L.drop (j + 1)).flatten := by
+  induction L generalizing i with
+  | nil =>
+    simp
+  | cons head tail tail_ih =>
+    have not_zero_gt_i : decide (0 > i) = false := by simp
+    rw [map_cons, partialSums_cons, findIdx_cons]
+    by_cases i_head_length : i < head.length
+    · rw [partialSums_unfold_once, map_cons, findIdx_cons]
+      simp [i_head_length]
+      rw [drop_append_of_le_length (by lia)]
+    · have i_ge_head_length := Nat.le_of_not_lt i_head_length
+      have ⟨goalJ, goalJ_def⟩ : ∃ j, j =
+        ((tail.map length).partialSums.map (head.length + ·)).findIdx (· > i) := by simp
+      rw [← goalJ_def]
+      specialize tail_ih (i - head.length)
+      rw [findIdx_thres_offset _ head.length, Nat.sub_add_cancel i_ge_head_length] at tail_ih
+      rw [← goalJ_def] at tail_ih
+      -- goalJ is succ
+      rw [partialSums_unfold_once] at goalJ_def
+      simp [findIdx_cons, i_head_length] at goalJ_def
+      have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
+      -- now with this information, the goal is essentially the same as tail_ih
+      simpa [goalJ_succ, drop_append, drop_of_length_le i_ge_head_length,
+        ← Nat.sub_sub] using tail_ih

--- a/Batteries/Data/List/Scan.lean
+++ b/Batteries/Data/List/Scan.lean
@@ -288,4 +288,5 @@ theorem take_flatten (L : List (List α)) (i : Nat) :
       simp [findIdx_cons, i_head_length] at goalJ_def
       have ⟨goalJ', goalJ_succ⟩ : ∃ goalJ', goalJ = goalJ' + 1 := by simp [goalJ_def]
       -- now with this information, the goal is essentially the same as tail_ih
-      simpa [goalJ_succ, take_append, take_of_length_le i_ge_head_length, ← Nat.sub_sub] using tail_ih
+      simpa [goalJ_succ, take_append, take_of_length_le i_ge_head_length,
+        ← Nat.sub_sub] using tail_ih


### PR DESCRIPTION
This PR adds a proof of `take_flatten` in `Batteries.Data.List.Scan`.

* The proof is done by induction on the list `L`.
  * Trivial if `L = nil`.
  * Otherwise, let `L = head :: tail` (induction hypothesis `tail_ih`). Case analysis on `i < head.length`.
    * If `i < head.length`, it can be proven that the result is equal to `head.take i`.
    * Otherwise, careful analysis shows that `tail_ih (i - head.length)` indeed has `j' = j - 1` and `j >= 1`,
      which can be used to simplify `tail_ih ..` and the goal to the same statement.

I tried to avoid `extract_lets` since then I have to explicitly state equalities afterwards, which makes the proof script quite messy.

The theorem statement and its description are not changed.

Lemmas added:

* `findIdx_thres_offset` is a very specialized lemma used in the proof of `take_flatten`.
* `partialSums_unfold_once` is a lemma that could be occasionally useful. It can be used to expose the head without doing case analysis on the list argument, which can then be manipulated with `map_cons`, `findIdx_cons`, etc.
* `scanl_unfold_once` is not used in this proof, but it is added since it has the same spirit as `partialSums_unfold_once` and is more general.