### PR TITLE
fix: unknown identifier when `❰…❱` references share a dependency

### DIFF
--- a/Batteries/Util/ProofWanted.lean
+++ b/Batteries/Util/ProofWanted.lean
@@ -444,20 +444,26 @@ private def elabWanted (kind : WantedCmdKind) (stx : Syntax)
   -- `❰J❱`) referenced but unbound.
   let surfaceDeps (deps : Array WantedDep) :
       CommandElabM (TSyntax `term → CommandElabM (TSyntax `term)) := do
+    let applyRenames (renames : Std.HashMap Name Name) (t : TSyntax `term) : TSyntax `term :=
+      if renames.isEmpty then t else
+      ⟨Id.run <| t.raw.replaceM fun s => do
+        if s.isIdent then
+          if let some r := renames[s.getId]? then return some (mkIdent r).raw
+        return none⟩
     let mut renames : Std.HashMap Name Name := {}
     for dep in deps do
       match (← nameToHypRef.get).find? dep.name with
       | some existing => renames := renames.insert dep.ident.getId existing.getId
       | none =>
         nameToHypRef.modify (·.insert dep.name dep.ident)
+        -- A dep's binder type may refer to an *earlier* dep of the same reference (e.g. `d_bc`'s
+        -- type mentions `d_J`); if that earlier dep was deduplicated against an existing binder,
+        -- the reference must follow the rename too, or it is left dangling.
         hypOrderRef.modify (·.push (dep.ident,
-          { kind := .defWanted, binderType := dep.binderType, isClass := dep.isClass }))
-    return fun t => do
-      if renames.isEmpty then return t
-      return ⟨← t.raw.replaceM fun s => do
-        if s.isIdent then
-          if let some r := renames[s.getId]? then return some (mkIdent r).raw
-        return none⟩
+          { kind := .defWanted, binderType := applyRenames renames dep.binderType,
+            isClass := dep.isClass }))
+    let finalRenames := renames
+    return fun t => pure (applyRenames finalRenames t)
   let rewriteRefs (s : Syntax) : CommandElabM Syntax := s.replaceM fun node => do
     unless node.getKind == ``wantedRef do return none
     let identStx : Syntax.Ident := ⟨node[1]⟩

--- a/BatteriesTest/def_wanted.lean
+++ b/BatteriesTest/def_wanted.lean
@@ -365,4 +365,13 @@ instance_wanted (n : Nat) : Baz (❰bc❱ n)
 
 theorem_wanted after_chained_instance : True
 
+/-! The same failure via an explicit reference: the statement binds `d_J` through `❰J❱`, and the
+body's `❰baz❱` carries the ambient `Pointed (❰J❱ n)` instance as a dependency whose binder type
+mentions `baz`'s own (deduplicated) `d_J`. -/
+private class Baz2 (a : Type) [Pointed a] : Prop
+
+theorem_wanted baz2 (n : Nat) : Baz2 (❰J❱ n)
+
+theorem_wanted baz2_and_true (n : Nat) : Baz2 (❰J❱ n) ∧ True := ⟨❰baz2❱ n, trivial⟩
+
 end InstWantedTests

--- a/BatteriesTest/def_wanted.lean
+++ b/BatteriesTest/def_wanted.lean
@@ -352,9 +352,10 @@ theorem_wanted chained_instances_synth : True := by
   trivial
 
 /-! An `instance_wanted` referencing a *chained* wanted (`bc` depends on `J`) alongside an
-earlier ambient instance on `J`. When a later declaration auto-includes both, `J` is deduplicated
-against the binder surfaced by the first include, and the surfaced `d_bc` binder's type must
-follow that rename rather than refer to the discarded fresh name. -/
+earlier ambient instance on `J`. When a later declaration's include-on-use probe tentatively
+includes both, `J` is deduplicated against the binder surfaced by the first include, and the
+surfaced `d_bc` binder's type must follow that rename rather than refer to the discarded fresh
+name. -/
 private class Baz {α β : Type} (f : α → β) : Prop
 
 def_wanted J (n : Nat) : Type

--- a/BatteriesTest/def_wanted.lean
+++ b/BatteriesTest/def_wanted.lean
@@ -351,4 +351,17 @@ theorem_wanted chained_instances_synth : True := by
   have : Stupid (❰W❱) := inferInstance
   trivial
 
+/-! An `instance_wanted` referencing a *chained* wanted (`bc` depends on `J`) alongside an
+earlier ambient instance on `J`. When a later declaration auto-includes both, `J` is deduplicated
+against the binder surfaced by the first include, and the surfaced `d_bc` binder's type must
+follow that rename rather than refer to the discarded fresh name. -/
+private class Baz {α β : Type} (f : α → β) : Prop
+
+def_wanted J (n : Nat) : Type
+instance_wanted (n : Nat) : Pointed (❰J❱ n)
+def_wanted bc (n : Nat) : ❰J❱ n → ❰J❱ (n + 1)
+instance_wanted (n : Nat) : Baz (❰bc❱ n)
+
+theorem_wanted after_chained_instance : True
+
 end InstWantedTests


### PR DESCRIPTION
This PR fixes an `Unknown identifier d_J✝` error in wanted declarations whose `❰…❱` references (or auto-included `instance_wanted`s) share a dependency. When a reference's dependencies are surfaced as binders, one already bound by an earlier reference is deduplicated and renamed, but the rename was only applied to the reference's own binder type. A newly surfaced sibling whose binder type mentioned the deduplicated one (e.g. `d_bc : ∀ n, DefWanted.Val (@bc n d_J)`) kept the discarded fresh name. The fix applies the accumulated renames to each newly surfaced dependency's binder type.

Two regression tests in `BatteriesTest/def_wanted.lean`, one via an auto-included instance and one via an explicit reference:

```lean
def_wanted J (n : Nat) : Type
instance_wanted (n : Nat) : Pointed (❰J❱ n)
def_wanted bc (n : Nat) : ❰J❱ n → ❰J❱ (n + 1)
instance_wanted (n : Nat) : Baz (❰bc❱ n)

theorem_wanted after_chained_instance : True  -- previously: Unknown identifier `d_J✝`

theorem_wanted baz2 (n : Nat) : Baz2 (❰J❱ n)
theorem_wanted baz2_and_true (n : Nat) : Baz2 (❰J❱ n) ∧ True := ⟨❰baz2❱ n, trivial⟩  -- likewise
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)